### PR TITLE
feat: enable unicorn/prefer-ternary ESLint rule and fix violations (closes #183)

### DIFF
--- a/package.json
+++ b/package.json
@@ -173,8 +173,7 @@
 			"unicorn/no-useless-promise-resolve-reject": "off",
 			"unicorn/no-for-loop": "off",
 			"unicorn/no-useless-switch-case": "off",
-			"no-implicit-coercion": "off",
-			"unicorn/prefer-ternary": "off"
+			"no-implicit-coercion": "off"
 		}
 	},
 	"prettier": "@vdemedes/prettier-config",

--- a/source/services/RemainingTimeAlignment.ts
+++ b/source/services/RemainingTimeAlignment.ts
@@ -152,11 +152,9 @@ export class RemainingTimeAlignment {
 		oldHours: number;
 		diff: number;
 	}> {
-		if (strategy === 'even') {
-			return this.distributeEvenly(issues, remainingHours);
-		} else {
-			return this.distributeProportionally(issues, remainingHours);
-		}
+		return strategy === 'even'
+			? this.distributeEvenly(issues, remainingHours)
+			: this.distributeProportionally(issues, remainingHours);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- Enable the `unicorn/prefer-ternary` ESLint rule by removing it from the "off" state in package.json
- Fix the single violation found in `RemainingTimeAlignment.ts` by converting an if-else statement to a ternary expression
- All tests pass with no remaining violations for this rule

## Changes Made
- **package.json**: Removed `"unicorn/prefer-ternary": "off"` from XO configuration
- **source/services/RemainingTimeAlignment.ts**: Converted if-else statement at line 155 to a ternary expression

## Test Results
- `npm run lint`: No more `unicorn/prefer-ternary` violations
- `npm test`: All 308 tests pass successfully

## Acceptance Criteria
- [x] `unicorn/prefer-ternary` rule is enabled in package.json
- [x] `npm run lint` shows no violations for this rule
- [x] `npm test` passes without errors
- [x] Pull request created and ready for review

Closes #183

🤖 Generated with [Claude Code](https://claude.ai/code)