### PR TITLE
feat: enable unicorn/no-useless-switch-case ESLint rule and fix violations (closes #181)

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,8 +171,7 @@
 			"unicorn/no-array-callback-reference": "off",
 			"no-prototype-builtins": "off",
 			"unicorn/no-useless-promise-resolve-reject": "off",
-			"unicorn/no-for-loop": "off",
-			"unicorn/no-useless-switch-case": "off"
+			"unicorn/no-for-loop": "off"
 		}
 	},
 	"prettier": "@vdemedes/prettier-config",

--- a/source/components/NotificationBar.tsx
+++ b/source/components/NotificationBar.tsx
@@ -23,7 +23,6 @@ export function NotificationBar({notifications}: NotificationBarProps) {
 				return 'green';
 			case 'error':
 				return 'red';
-			case 'info':
 			default:
 				return 'blue';
 		}

--- a/source/components/WeeklyTimetableView.tsx
+++ b/source/components/WeeklyTimetableView.tsx
@@ -402,7 +402,6 @@ export function WeeklyTimetableView({
 								/>
 							);
 
-						case 'timetable':
 						default:
 							return (
 								<TimetableGrid


### PR DESCRIPTION
## Summary
- Enable the `unicorn/no-useless-switch-case` ESLint rule by removing it from the "off" state in package.json
- Fix the violations found in two files by removing useless switch cases that fell through to default
- All tests pass with no remaining violations for this rule

## Changes Made
- **package.json**: Removed `"unicorn/no-useless-switch-case": "off"` from XO configuration
- **source/components/NotificationBar.tsx**: Removed useless `case 'info':` that fell through to default (line 26)
- **source/components/WeeklyTimetableView.tsx**: Removed useless `case 'timetable':` that fell through to default (line 405)

## Test Results
- `npm run lint`: No more `unicorn/no-useless-switch-case` violations
- `npm test`: All 308 tests pass successfully

## Acceptance Criteria
- [x] `unicorn/no-useless-switch-case` rule is enabled in package.json
- [x] `npm run lint` shows no violations for this rule
- [x] `npm test` passes without errors
- [x] Pull request created and ready for review

Closes #181

🤖 Generated with [Claude Code](https://claude.ai/code)