### PR TITLE
Enable unicorn/no-array-callback-reference ESLint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -168,7 +168,6 @@
 			"@typescript-eslint/return-await": "off",
 			"no-return-await": "off",
 			"@typescript-eslint/class-literal-property-style": "off",
-			"unicorn/no-array-callback-reference": "off",
 			"no-prototype-builtins": "off",
 			"unicorn/no-useless-promise-resolve-reject": "off",
 			"unicorn/no-for-loop": "off"

--- a/source/utils/FocusableItemCalculator.ts
+++ b/source/utils/FocusableItemCalculator.ts
@@ -60,14 +60,14 @@ export class FocusableItemCalculator {
 		items: FocusableItem[],
 		predicate: (item: FocusableItem) => boolean,
 	): FocusableItem | undefined {
-		return items.find(predicate);
+		return items.find(item => predicate(item));
 	}
 
 	static filterFocusableItems(
 		items: FocusableItem[],
 		predicate: (item: FocusableItem) => boolean,
 	): FocusableItem[] {
-		return items.filter(predicate);
+		return items.filter(item => predicate(item));
 	}
 
 	static getFocusableItemsByColumn(


### PR DESCRIPTION
Enable the `unicorn/no-array-callback-reference` ESLint rule and fix all violations.

## Changes
- Remove `"unicorn/no-array-callback-reference": "off"` from package.json XO configuration
- Fix violations in FocusableItemCalculator.ts by wrapping predicate functions in arrow functions
- All tests pass (640 tests ✅)

Fixes #177

🤖 Generated with [Claude Code](https://claude.ai/code)