### PR TITLE
Enable unicorn/no-for-loop ESLint rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,8 +170,7 @@
 			"@typescript-eslint/class-literal-property-style": "off",
 			"unicorn/no-array-callback-reference": "off",
 			"no-prototype-builtins": "off",
-			"unicorn/no-useless-promise-resolve-reject": "off",
-			"unicorn/no-for-loop": "off"
+			"unicorn/no-useless-promise-resolve-reject": "off"
 		}
 	},
 	"prettier": "@vdemedes/prettier-config",

--- a/source/tests/components/TimetableGrid.groups.test.tsx
+++ b/source/tests/components/TimetableGrid.groups.test.tsx
@@ -205,8 +205,7 @@ test('TimetableGrid sorts groups by name and issues within groups by key', t => 
 	let defIndex = -1;
 	let monIndex = -1;
 
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+	for (const [i, line] of lines.entries()) {
 		if (line && line.includes('ABC-5417')) {
 			abcIndex = i;
 		} else if (line && line.includes('DEF-2456')) {
@@ -325,8 +324,7 @@ test('TimetableGrid handles mixed group assignments correctly', t => {
 	let defIndex = -1;
 	let monIndex = -1;
 
-	for (let i = 0; i < lines.length; i++) {
-		const line = lines[i];
+	for (const [i, line] of lines.entries()) {
 		if (line && line.includes('ABC-5417')) {
 			abcIndex = i;
 		} else if (line && line.includes('DEF-2456')) {


### PR DESCRIPTION
Fixes #180

This PR enables the `unicorn/no-for-loop` ESLint rule and fixes all violations.

## Changes
- Removed `"unicorn/no-for-loop": "off"` from package.json XO configuration
- Fixed 2 violations in TimetableGrid.groups.test.tsx by converting for-loops to for-of loops with entries()
- All tests pass

## Validation
- `npm run lint` shows no violations
- `npm test` passes without errors

Generated with [Claude Code](https://claude.ai/code)