### PR TITLE
Enable eqeqeq ESLint rule and fix violations

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,7 +156,6 @@
 			"@typescript-eslint/ban-ts-comment": "off",
 			"@typescript-eslint/restrict-plus-operands": "off",
 			"no-eq-null": "off",
-			"eqeqeq": "off",
 			"@typescript-eslint/no-floating-promises": "off",
 			"unicorn/prefer-module": "off",
 			"max-params": "off",

--- a/source/tests/integration/worklog-form-flow.integration.test.tsx
+++ b/source/tests/integration/worklog-form-flow.integration.test.tsx
@@ -117,7 +117,10 @@ test('Integration: Component renders without errors', async t => {
 	await waitFor(() => {
 		const output = lastFrame();
 		return (
-			output != null && output.includes('Week') && output.includes('[Q] Quit')
+			output !== null &&
+			output !== undefined &&
+			output.includes('Week') &&
+			output.includes('[Q] Quit')
 		);
 	});
 
@@ -157,7 +160,7 @@ test('Integration: Component handles API errors gracefully', async t => {
 	// Wait for component to stabilize despite API errors
 	await waitFor(() => {
 		const output = lastFrame();
-		return output != null && output.includes('Week');
+		return output !== null && output !== undefined && output.includes('Week');
 	});
 
 	// Verify component still renders correctly despite API errors
@@ -195,7 +198,7 @@ test('Integration: Component accepts different configurations', async t => {
 
 	await waitFor(() => {
 		const output = lastFrame();
-		return output != null && output.includes('Week');
+		return output !== null && output !== undefined && output.includes('Week');
 	});
 
 	// Wait for potential API calls
@@ -237,7 +240,7 @@ test('Integration: Component lifecycle completes', async t => {
 	// Wait for component lifecycle to complete
 	await waitFor(() => {
 		const output = lastFrame();
-		return output != null && output.includes('Week');
+		return output !== null && output !== undefined && output.includes('Week');
 	});
 
 	// Verify component is functional before unmounting


### PR DESCRIPTION
Enable the `eqeqeq` ESLint rule and fix all violations to improve code quality and consistency.

## Changes
- Remove `"eqeqeq": "off"` from package.json XO configuration
- Fix 4 violations in worklog-form-flow.integration.test.tsx
- Change `!=` to `!==` for strict equality comparison
- Add null and undefined checks to satisfy TypeScript

## Verification
- ✅ `npm run quality:check` shows no violations
- ✅ `npm test` passes all 823 tests
- ✅ Rule is now enabled and enforced

Fixes #165

🤖 Generated with [Claude Code](https://claude.ai/code)