### PR TITLE
Enable ESLint rules and fix violations (#91 - #95)

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,11 +78,6 @@
 				}
 			],
 			"@typescript-eslint/restrict-template-expressions": "off",
-			"@typescript-eslint/no-confusing-void-expression": "off",
-			"unicorn/prefer-regexp-test": "off",
-			"unicorn/prefer-optional-catch-binding": "off",
-			"unicorn/prefer-spread": "off",
-			"unicorn/prefer-string-starts-ends-with": "off",
 			"@typescript-eslint/prefer-string-starts-ends-with": "off",
 			"@typescript-eslint/prefer-includes": "off",
 			"object-shorthand": "off",

--- a/source/components/AlignTimeConfirmation.tsx
+++ b/source/components/AlignTimeConfirmation.tsx
@@ -66,8 +66,12 @@ export function AlignTimeConfirmation({
 				<Text> </Text>
 				<ConfirmInput
 					submitOnEnter={false}
-					onConfirm={() => onConfirm(true)}
-					onCancel={() => onConfirm(false)}
+					onConfirm={() => {
+						onConfirm(true);
+					}}
+					onCancel={() => {
+						onConfirm(false);
+					}}
 				/>
 			</Box>
 		);
@@ -108,8 +112,12 @@ export function AlignTimeConfirmation({
 				<Text> </Text>
 				<ConfirmInput
 					submitOnEnter={false}
-					onConfirm={() => onConfirm(true)}
-					onCancel={() => onConfirm(false)}
+					onConfirm={() => {
+						onConfirm(true);
+					}}
+					onCancel={() => {
+						onConfirm(false);
+					}}
 				/>
 			</Box>
 		);
@@ -123,8 +131,12 @@ export function AlignTimeConfirmation({
 			</Text>
 			<ConfirmInput
 				submitOnEnter={false}
-				onConfirm={() => onConfirm(false)}
-				onCancel={() => onConfirm(false)}
+				onConfirm={() => {
+					onConfirm(false);
+				}}
+				onCancel={() => {
+					onConfirm(false);
+				}}
 			/>
 		</Box>
 	);

--- a/source/components/AttendanceEditForm.tsx
+++ b/source/components/AttendanceEditForm.tsx
@@ -188,7 +188,9 @@ export function AttendanceEditForm({
 							label=""
 							value={checkIn}
 							onChange={setCheckIn}
-							onSubmit={() => setFocusArea('checkOut')}
+							onSubmit={() => {
+								setFocusArea('checkOut');
+							}}
 							compact={true}
 						/>
 					) : (
@@ -204,7 +206,9 @@ export function AttendanceEditForm({
 							label=""
 							value={checkOut}
 							onChange={setCheckOut}
-							onSubmit={() => setFocusArea('break')}
+							onSubmit={() => {
+								setFocusArea('break');
+							}}
 							compact={true}
 						/>
 					) : (
@@ -219,7 +223,9 @@ export function AttendanceEditForm({
 						<DurationInput
 							value={breakMinutes}
 							onChange={setBreakMinutes}
-							onSubmit={() => setFocusArea('submit')}
+							onSubmit={() => {
+								setFocusArea('submit');
+							}}
 							compact={true}
 							allowedUnits={['h', 'm']}
 							incrementMinutes={15}

--- a/source/components/CheckinConfirmation.tsx
+++ b/source/components/CheckinConfirmation.tsx
@@ -15,8 +15,12 @@ export function CheckinConfirmation({onConfirm}: CheckinConfirmationProps) {
 			<Text>Do you want to check in and start work for today?</Text>
 			<ConfirmInput
 				submitOnEnter={true}
-				onConfirm={() => onConfirm(true)}
-				onCancel={() => onConfirm(false)}
+				onConfirm={() => {
+					onConfirm(true);
+				}}
+				onCancel={() => {
+					onConfirm(false);
+				}}
 			/>
 		</Box>
 	);

--- a/source/components/CheckoutConfirmation.tsx
+++ b/source/components/CheckoutConfirmation.tsx
@@ -15,8 +15,12 @@ export function CheckoutConfirmation({onConfirm}: CheckoutConfirmationProps) {
 			<Text>Do you want to check out and end work for today?</Text>
 			<ConfirmInput
 				submitOnEnter={true}
-				onConfirm={() => onConfirm(true)}
-				onCancel={() => onConfirm(false)}
+				onConfirm={() => {
+					onConfirm(true);
+				}}
+				onCancel={() => {
+					onConfirm(false);
+				}}
 			/>
 		</Box>
 	);

--- a/source/components/Confirmation.tsx
+++ b/source/components/Confirmation.tsx
@@ -15,8 +15,12 @@ export function Confirmation({title, message, onConfirm}: ConfirmationProps) {
 			<Text>{message}</Text>
 			<ConfirmInput
 				submitOnEnter={false}
-				onConfirm={() => onConfirm(true)}
-				onCancel={() => onConfirm(false)}
+				onConfirm={() => {
+					onConfirm(true);
+				}}
+				onCancel={() => {
+					onConfirm(false);
+				}}
 			/>
 		</Box>
 	);

--- a/source/components/InlineWorklogForm.tsx
+++ b/source/components/InlineWorklogForm.tsx
@@ -287,13 +287,13 @@ export function InlineWorklogForm({
 		setDateInputValue(value);
 
 		// Only update the date state if it's a valid date format
-		if (value.match(/^\d{4}-\d{2}-\d{2}$/)) {
+		if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
 			try {
 				const newDate = new Date(value + 'T00:00:00.000Z');
 				if (!isNaN(newDate.getTime())) {
 					setCurrentDate(newDate);
 				}
-			} catch (error) {
+			} catch {
 				// Ignore invalid dates
 			}
 		}
@@ -404,7 +404,9 @@ export function InlineWorklogForm({
 						<SimpleDateInput
 							value={dateInputValue || ''}
 							onChange={handleDateChange}
-							onSubmit={() => setFocusArea('time')}
+							onSubmit={() => {
+								setFocusArea('time');
+							}}
 							isActive={focusArea === 'date'}
 						/>
 					</Box>
@@ -419,7 +421,9 @@ export function InlineWorklogForm({
 						<DurationInput
 							value={timeInputValue}
 							onChange={handleTimeInputChange}
-							onSubmit={() => setFocusArea('comment')}
+							onSubmit={() => {
+								setFocusArea('comment');
+							}}
 							compact={true}
 							config={config}
 							issueSelectionMode={isFavorite ? 'favorites' : null}

--- a/source/components/RainbowText.tsx
+++ b/source/components/RainbowText.tsx
@@ -11,7 +11,7 @@ export function RainbowText({children, bold = false}: RainbowTextProps) {
 
 	return (
 		<>
-			{children.split('').map((char, index) => (
+			{[...children].map((char, index) => (
 				<Text
 					key={`char-${index}`}
 					color={colors[index % colors.length]}

--- a/source/components/TimeInputField.tsx
+++ b/source/components/TimeInputField.tsx
@@ -32,7 +32,7 @@ export default function TimeInputField({
 		const newValue = currentValue + char;
 
 		// Don't allow starting with colon
-		if (/^:/.test(newValue)) return false;
+		if (newValue.startsWith(':')) return false;
 
 		// Don't allow multiple colons
 		if ((newValue.match(/:/g) || []).length > 1) return false;

--- a/source/components/WeeklyTimetableView.tsx
+++ b/source/components/WeeklyTimetableView.tsx
@@ -108,7 +108,9 @@ export function WeeklyTimetableView({
 		config,
 		userEmail,
 		onRefresh: refresh,
-		onActiveAreaChange: (area: string) => setActiveArea(area as any),
+		onActiveAreaChange: (area: string) => {
+			setActiveArea(area as any);
+		},
 		data,
 	});
 
@@ -126,7 +128,9 @@ export function WeeklyTimetableView({
 	} = useAttendanceManagement({
 		config,
 		onRefresh: refresh,
-		onActiveAreaChange: (area: string) => setActiveArea(area as any),
+		onActiveAreaChange: (area: string) => {
+			setActiveArea(area as any);
+		},
 	});
 
 	// Delete operations state management
@@ -144,7 +148,9 @@ export function WeeklyTimetableView({
 		config,
 		userEmail,
 		onRefresh: refresh,
-		onActiveAreaChange: (area: string) => setActiveArea(area as any),
+		onActiveAreaChange: (area: string) => {
+			setActiveArea(area as any);
+		},
 		attendanceManager,
 		onAttendanceRefresh: refreshAttendance,
 	});
@@ -206,7 +212,9 @@ export function WeeklyTimetableView({
 			refresh();
 		}, 100);
 
-		return () => clearTimeout(timer);
+		return () => {
+			clearTimeout(timer);
+		};
 	}, []); // Empty dependency array means this runs only on mount
 
 	const handleOpenInBrowser = async (issueKey: string) => {

--- a/source/hooks/useDeleteOperations.ts
+++ b/source/hooks/useDeleteOperations.ts
@@ -201,7 +201,9 @@ export function useDeleteOperations(
 			const timer = setTimeout(() => {
 				setDeleteError(null);
 			}, 5000);
-			return () => clearTimeout(timer);
+			return () => {
+				clearTimeout(timer);
+			};
 		}
 		return undefined;
 	}, [deleteError]);

--- a/source/services/IssueGroupManager.ts
+++ b/source/services/IssueGroupManager.ts
@@ -48,7 +48,7 @@ export class IssueGroupManager {
 			}
 		}
 
-		const groups = Array.from(groupMap.values());
+		const groups = [...groupMap.values()];
 
 		for (const group of groups) {
 			group.issues = this.sortIssuesByKey(group.issues);

--- a/source/tests/hooks/useIssueGroups.test.ts
+++ b/source/tests/hooks/useIssueGroups.test.ts
@@ -37,7 +37,7 @@ test('useIssueGroups - hook exists and returns expected structure', t => {
 		// This will throw in a non-React environment, but that's expected
 		useIssueGroups(issues, config);
 		t.fail('Hook should not work outside React context');
-	} catch (error) {
+	} catch {
 		// Expected behavior - hooks can't be called outside React components
 		t.pass('Hook correctly fails outside React context');
 	}
@@ -54,7 +54,7 @@ test('useIssueGroups - handles null config', t => {
 	try {
 		useIssueGroups(issues, null);
 		t.fail('Hook should not work outside React context');
-	} catch (error) {
+	} catch {
 		t.pass('Hook correctly fails outside React context');
 	}
 });
@@ -80,7 +80,7 @@ test('useIssueGroups - handles empty issues array', t => {
 	try {
 		useIssueGroups(issues, config);
 		t.fail('Hook should not work outside React context');
-	} catch (error) {
+	} catch {
 		t.pass('Hook correctly fails outside React context');
 	}
 });
@@ -132,7 +132,7 @@ test('useIssueGroups - accepts complex config correctly', t => {
 	try {
 		useIssueGroups(issues, config);
 		t.fail('Hook should not work outside React context');
-	} catch (error) {
+	} catch {
 		t.pass('Hook correctly fails outside React context');
 	}
 });

--- a/source/tests/hooks/useTableNavigation.test.tsx
+++ b/source/tests/hooks/useTableNavigation.test.tsx
@@ -257,8 +257,14 @@ test('useTableNavigation: result methods maintain hook contract', t => {
 		.__testTableNavigationResult as TableNavigationResult;
 
 	// Verify that methods can be called without throwing
-	t.notThrows(() => result.handleFocusChange('PROJECT-123', 0, true));
-	t.notThrows(() => result.setFocusedCell(null));
-	t.notThrows(() => result.clearFocus());
+	t.notThrows(() => {
+		result.handleFocusChange('PROJECT-123', 0, true);
+	});
+	t.notThrows(() => {
+		result.setFocusedCell(null);
+	});
+	t.notThrows(() => {
+		result.clearFocus();
+	});
 	t.notThrows(() => result.isCellFocused('PROJECT-123', 0));
 });

--- a/source/tests/utils/testUtils.ts
+++ b/source/tests/utils/testUtils.ts
@@ -238,7 +238,9 @@ export const hookTestUtils = {
 	createMockAsyncOperation<T>(result: T, delay: number = 100) {
 		return () =>
 			new Promise<T>(resolve => {
-				setTimeout(() => resolve(result), delay);
+				setTimeout(() => {
+					resolve(result);
+				}, delay);
 			});
 	},
 };

--- a/source/use-cases/WeeklyWorklogSummaryUseCase.ts
+++ b/source/use-cases/WeeklyWorklogSummaryUseCase.ts
@@ -121,7 +121,7 @@ export class WeeklyWorklogSummaryUseCase {
 
 		// Fetch detailed worklogs for each issue
 		const issuesWithWorklogs: IssueWithWorklogs[] = await Promise.all(
-			Array.from(allIssueKeys).map(async issueKey => {
+			[...allIssueKeys].map(async issueKey => {
 				// Find issue data from either worklogs search, sliding window search, or favorites
 				const worklogIssue = searchResult.issues.find(
 					issue => issue.key === issueKey,
@@ -297,7 +297,7 @@ export class WeeklyWorklogSummaryUseCase {
 		});
 
 		// Convert map to sorted array
-		return Array.from(dailyWorklogMap.values()).sort(
+		return [...dailyWorklogMap.values()].sort(
 			(a, b) => a.date.getTime() - b.date.getTime(),
 		);
 	}


### PR DESCRIPTION
## Summary
Enable and fix violations for ESLint rules from GitHub issues #91-#95:

- **@typescript-eslint/no-confusing-void-expression**: Add braces to arrow functions that call void methods to clarify intent and avoid confusing return semantics
- **unicorn/prefer-regexp-test**: Replace `String#match()` with `RegExp#test()` for boolean checks to improve performance and clarity  
- **unicorn/prefer-optional-catch-binding**: Remove unused catch parameters when error details aren't needed
- **unicorn/prefer-spread**: Use spread operator `[...array]` and `[...string]` instead of `Array.from()` and `String#split('')` for better readability
- **unicorn/prefer-string-starts-ends-with**: Replace regex patterns with `String.prototype.startsWith()` for cleaner string prefix checks

## Test plan
- [x] Enable rules in package.json by removing `"off"` settings
- [x] Run `npm run lint` to identify all violations
- [x] Fix all 37 violations across 16 files 
- [x] Run `npm test` to ensure all tests pass (829 tests passing)
- [x] Run `npm run quality:check` to verify no linting errors remain

🤖 Generated with [Claude Code](https://claude.ai/code)