### PR TITLE
Enable @typescript-eslint/restrict-plus-operands ESLint rule (#162)

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
 			"import/first": "error",
 			"@typescript-eslint/consistent-type-assertions": "off",
 			"@typescript-eslint/ban-ts-comment": "off",
-			"@typescript-eslint/restrict-plus-operands": "off",
 			"no-eq-null": "off",
 			"@typescript-eslint/no-floating-promises": "off",
 			"unicorn/prefer-module": "off",

--- a/source/services/IssueGroupManager.ts
+++ b/source/services/IssueGroupManager.ts
@@ -43,7 +43,7 @@ export class IssueGroupManager {
 				}
 
 				groupMap.get(groupId)!.issues.push([issueKey, issueData]);
-				groupMap.get(groupId)!.totalHours += issueData.weekTotal;
+				groupMap.get(groupId)!.totalHours += issueData.weekTotal as number;
 			} else {
 				ungroupedIssues.push([issueKey, issueData]);
 			}


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/restrict-plus-operands` ESLint rule by removing it from disabled configuration
- Fix type safety violation in IssueGroupManager where `any` type was being used with + operator
- All existing violations have been fixed with explicit type casting

## Changes
- Removed `@typescript-eslint/restrict-plus-operands: "off"` from package.json XO configuration  
- Added type cast to `number` for `issueData.weekTotal` in IssueGroupManager.ts:46

## Test Plan
- [x] `npm run lint` passes without violations
- [x] `npm test` passes all existing tests
- [x] Code maintains existing functionality with improved type safety

🤖 Generated with [Claude Code](https://claude.ai/code)