### PR TITLE
Enable @typescript-eslint/no-floating-promises ESLint rule (#166)

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,7 +119,6 @@
 			"@typescript-eslint/ban-ts-comment": "off",
 			"@typescript-eslint/restrict-plus-operands": "off",
 			"no-eq-null": "off",
-			"@typescript-eslint/no-floating-promises": "off",
 			"unicorn/prefer-module": "off",
 			"max-params": "off",
 			"@typescript-eslint/no-require-imports": "off",

--- a/source/components/TimetableGrid.tsx
+++ b/source/components/TimetableGrid.tsx
@@ -76,7 +76,7 @@ export function TimetableGrid({
 			}
 		};
 
-		loadAttendanceData();
+		void loadAttendanceData();
 	}, [attendanceManager, data, attendanceRefreshKey]);
 
 	// CALL ALL HOOKS FIRST (before any conditional returns)

--- a/source/hooks/useConfig.ts
+++ b/source/hooks/useConfig.ts
@@ -65,7 +65,7 @@ export function useConfig(providedConfig?: JiraConfig): UseConfigResult {
 			}
 		}
 
-		loadConfigAndUser();
+		void loadConfigAndUser();
 	}, [providedConfig]);
 
 	// Cleanup reminder service on unmount

--- a/source/hooks/useWeeklyWorklogSummary.ts
+++ b/source/hooks/useWeeklyWorklogSummary.ts
@@ -81,7 +81,7 @@ export function useWeeklyWorklogSummary(
 
 	useEffect(() => {
 		if (!skipAutoLoad) {
-			fetchData();
+			void fetchData();
 		}
 	}, [weekStart, weekEnd, config, skipAutoLoad, userEmail, favoriteIssues]);
 
@@ -100,7 +100,7 @@ export function useWeeklyWorklogSummary(
 			normalizedWindow.past
 		}:${normalizedWindow.future}`;
 		weekDataCache.delete(cacheKey);
-		fetchData();
+		void fetchData();
 	};
 
 	return {data, isLoading, error, refresh};


### PR DESCRIPTION
## Summary
- Enable `@typescript-eslint/no-floating-promises` ESLint rule by removing it from disabled configuration
- Fix all floating promise violations by explicitly marking them with `void` operator
- Ensures proper promise handling throughout the codebase

## Changes
- Removed `@typescript-eslint/no-floating-promises: "off"` from package.json XO configuration
- Added `void` operator to intentionally floating promises in:
  - `useWeeklyWorklogSummary.ts` - useEffect data fetching calls
  - `TimetableGrid.tsx` - async attendance data loading  
  - `useConfig.ts` - async config and user loading

## Test Plan  
- [x] `npm run lint` passes without violations
- [x] `npm test` passes all existing tests
- [x] Code maintains existing functionality with better promise handling

🤖 Generated with [Claude Code](https://claude.ai/code)