### PR TITLE
Reduce max-lines ESLint rule limit from 1200 to 800

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
 			"max-lines": [
 				"error",
 				{
-					"max": 1200,
+					"max": 800,
 					"skipComments": true,
 					"skipBlankLines": true
 				}


### PR DESCRIPTION
## Summary
- Reduced the ESLint max-lines rule limit from 1200 to 800 lines
- Part of progressive file size enforcement initiative to promote better code organization
- All existing files already comply with the new 800-line limit

## Changes Made
- Updated `max-lines` rule configuration in `package.json` from 1200 to 800
- No code refactoring was needed as all files are already under the 800-line limit

## Verification
- ✅ ESLint passes with no violations (`npm run lint`)
- ✅ All tests pass (812/812 tests passed)
- ✅ No files exceed the new 800-line limit

## Implementation Strategy
As outlined in the issue, this change follows the progressive approach:
1. ✅ Previous step: Reduce to 1200 lines
2. ✅ **Current step: Reduce to 800 lines** 
3. 🔄 Next step: Reduce to 500 lines

This incremental approach ensures code quality is maintained while encouraging better separation of concerns and more maintainable code structure.

Closes #82

🤖 Generated with [Claude Code](https://claude.ai/code)