### PR TITLE
Set sliding window default to 7 days for better UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,24 @@ Create `~/.config/jiracle.json`:
 	"apiToken": "your-jira-api-token",
 	"defaultTime": "4h",
 	"defaultComment": "Development work",
-	"favorites": [{"key": "PROJ-123", "alias": "Main Feature"}]
+	"favorites": [{"key": "PROJ-123", "alias": "Main Feature"}],
+	"slidingWindowDays": {
+		"past": 7,
+		"future": 0
+	}
 }
 ```
+
+### Configuration Options
+
+#### Sliding Window
+
+The `slidingWindowDays` option controls which recently worked issues appear in new weeks:
+
+- `past`: Number of days to look back for recent issues (default: 7)
+- `future`: Number of days to look ahead (default: 0)
+
+Example: Issues worked on in the last 7 days will automatically appear in new weeks, even if no time has been logged yet that week.
 
 Get API token: [Atlassian Account Settings](https://id.atlassian.com/manage-profile/security/api-tokens)
 

--- a/source/jira/utils.ts
+++ b/source/jira/utils.ts
@@ -15,7 +15,7 @@ export function normalizeSlidingWindowConfig(
 	const slidingWindow = config.slidingWindowDays;
 
 	if (!slidingWindow) {
-		return {past: 0, future: 0};
+		return {past: 7, future: 0};
 	}
 
 	return {

--- a/source/tests/use-cases/WeeklyWorklogSummaryUseCase/sliding-window/basic-scenarios.test.ts
+++ b/source/tests/use-cases/WeeklyWorklogSummaryUseCase/sliding-window/basic-scenarios.test.ts
@@ -197,6 +197,6 @@ test('normalizeSlidingWindowConfig handles configuration formats', t => {
 		apiToken: 'test',
 	};
 	normalized = normalizeSlidingWindowConfig(emptyConfig);
-	t.is(normalized.past, 0);
+	t.is(normalized.past, 7);
 	t.is(normalized.future, 0);
 });


### PR DESCRIPTION
## Summary
- Set default `slidingWindowDays.past` from 0 to 7 days to enable the sliding window feature by default
- Add comprehensive README documentation for `slidingWindowDays` configuration
- Update test assertions to match the new default value

## Problem
The sliding window feature allows recently worked issues to appear in new weeks, even when no time has been logged yet that week. However, the default configuration was `{past: 0, future: 0}`, which effectively disabled this helpful feature.

When users switched from one week to another (e.g., from KW28 to KW30), recently worked issues like GVV items would disappear from the timetable, forcing users to manually navigate back or search for them again.

## Solution
1. **Changed default value**: `normalizeSlidingWindowConfig()` now returns `{past: 7, future: 0}` when no configuration is provided
2. **Updated documentation**: Added clear explanation of `slidingWindowDays` in README with examples
3. **Fixed tests**: Updated test assertions to expect the new default value

## Test plan
- [x] All existing tests pass with the new default
- [x] `normalizeSlidingWindowConfig` test updated to expect `past: 7`
- [x] Sliding window functionality continues to work as expected
- [x] Users without explicit configuration now benefit from 7-day lookback by default

🤖 Generated with [Claude Code](https://claude.ai/code)