### PR TITLE
Fix type-checking test in useConfirmation.test.tsx

### DIFF
--- a/source/tests/hooks/useConfirmation.test.tsx
+++ b/source/tests/hooks/useConfirmation.test.tsx
@@ -112,7 +112,11 @@ test('useConfirmation show() displays dialog with custom config', async t => {
 		expectedConfig.paddingX,
 		'Should apply custom padding',
 	);
-	t.not(hookState!.onConfirm, undefined, 'Should set confirm handler');
+	t.is(
+		typeof hookState!.onConfirm,
+		'function',
+		'Should set confirm handler as function',
+	);
 
 	// Clean up
 	hookState!.handleConfirm(false);


### PR DESCRIPTION
## Summary
- Replace generic existence check with specific function type verification in useConfirmation.test.tsx:116
- Previously used `t.not(hookState\!.onConfirm, undefined)` which only checked for existence
- Now uses `t.is(typeof hookState\!.onConfirm, 'function')` to verify the handler is actually a function

## Test plan
- [x] Run `npm test -- --match "*useConfirmation*"` to verify all useConfirmation tests pass
- [x] Verify the specific test case properly validates the function type instead of just existence
- [x] Confirm the change follows the Test Data Pattern from guidelines/tests.md

🤖 Generated with [Claude Code](https://claude.ai/code)