### PR TITLE
Fix useFocusManagement test to test actual behavior instead of types

### DIFF
--- a/source/tests/hooks/useFocusManagement.test.tsx
+++ b/source/tests/hooks/useFocusManagement.test.tsx
@@ -1,5 +1,5 @@
 import test from 'ava';
-import React from 'react';
+import React, {act} from 'react';
 import {Box, Text} from 'ink';
 import {render} from 'ink-testing-library';
 import {
@@ -7,13 +7,20 @@ import {
 	type UseFocusManagementResult,
 } from '../../hooks/useFocusManagement.js';
 
-// Test component that captures hook state during render
-function TestFocusManagementComponent() {
+// Test component that uses the focus management hook and reports state changes
+function TestFocusManagementComponent({
+	onStateChange,
+}: {
+	onStateChange?: (state: UseFocusManagementResult) => void;
+}) {
 	const focusManagement = useFocusManagement();
 
-	// Store hook result in a global variable for testing (test-only pattern)
-	// @ts-expect-error: Test-only global variable to access hook state
-	globalThis.__testHookResult = focusManagement;
+	// Report state changes to test
+	React.useEffect(() => {
+		if (onStateChange) {
+			onStateChange(focusManagement);
+		}
+	}); // No dependencies - runs on every render
 
 	return (
 		<Box>
@@ -22,15 +29,262 @@ function TestFocusManagementComponent() {
 	);
 }
 
-test('useFocusManagement: returns initial state with null focused cell', t => {
-	render(React.createElement(TestFocusManagementComponent));
+test('useFocusManagement: returns initial state with undefined focused cell', t => {
+	// Explicit test data
+	const expectedInitialCell = undefined;
 
-	// @ts-expect-error: Test-only global variable to access hook state
-	const hook = globalThis.__testHookResult as UseFocusManagementResult;
-	t.truthy(hook);
-	t.is(hook.focusedCell, undefined);
-	t.is(typeof hook.handleFocusChange, 'function');
-	t.is(typeof hook.setFocusedCell, 'function');
-	t.is(typeof hook.clearFocus, 'function');
-	t.is(typeof hook.isCellFocused, 'function');
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.is(capturedState!.focusedCell, expectedInitialCell);
+});
+
+test('useFocusManagement: handles focus change to regular issue', t => {
+	// Explicit test data
+	const testIssueKey = 'PROJ-123';
+	const testColumnIndex = 2;
+	const isFocused = true;
+	const expectedFocusedCell = {
+		issueKey: 'PROJ-123',
+		columnIndex: 2,
+		isAttendance: false,
+	};
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(testIssueKey, testColumnIndex, isFocused);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.deepEqual(capturedState!.focusedCell, expectedFocusedCell);
+});
+
+test('useFocusManagement: handles focus change to attendance issue', t => {
+	// Explicit test data
+	const testIssueKey = 'attendance-sick';
+	const testColumnIndex = 1;
+	const isFocused = true;
+	const expectedFocusedCell = {
+		issueKey: 'attendance-sick',
+		columnIndex: 1,
+		isAttendance: true,
+	};
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(testIssueKey, testColumnIndex, isFocused);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.deepEqual(capturedState!.focusedCell, expectedFocusedCell);
+});
+
+test('useFocusManagement: ignores blur events', t => {
+	// Explicit test data
+	const testIssueKey = 'PROJ-456';
+	const testColumnIndex = 0;
+	const initialFocusedCell = {
+		issueKey: 'PROJ-456',
+		columnIndex: 0,
+		isAttendance: false,
+	};
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(testIssueKey, testColumnIndex, true);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(testIssueKey, testColumnIndex, false);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.deepEqual(capturedState!.focusedCell, initialFocusedCell);
+});
+
+test('useFocusManagement: clears focus correctly', t => {
+	// Explicit test data
+	const testIssueKey = 'PROJ-789';
+	const testColumnIndex = 3;
+	const expectedClearedCell = undefined;
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(testIssueKey, testColumnIndex, true);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.clearFocus();
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.is(capturedState!.focusedCell, expectedClearedCell);
+});
+
+test('useFocusManagement: checks if cell is focused correctly', t => {
+	// Explicit test data
+	const focusedIssueKey = 'PROJ-111';
+	const focusedColumnIndex = 1;
+	const differentIssueKey = 'PROJ-222';
+	const differentColumnIndex = 2;
+	const expectedFocusedResult = true;
+	const expectedNotFocusedResult = false;
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.handleFocusChange(focusedIssueKey, focusedColumnIndex, true);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.is(
+		capturedState!.isCellFocused(focusedIssueKey, focusedColumnIndex),
+		expectedFocusedResult,
+	);
+	t.is(
+		capturedState!.isCellFocused(differentIssueKey, differentColumnIndex),
+		expectedNotFocusedResult,
+	);
+});
+
+test('useFocusManagement: setFocusedCell updates state directly', t => {
+	// Explicit test data
+	const testCell = {
+		issueKey: 'DIRECT-SET',
+		columnIndex: 4,
+		isAttendance: true,
+	};
+
+	// Operations
+	let capturedState: UseFocusManagementResult;
+	const {rerender} = render(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	act(() => {
+		capturedState!.setFocusedCell(testCell);
+	});
+
+	rerender(
+		React.createElement(TestFocusManagementComponent, {
+			onStateChange(state: UseFocusManagementResult) {
+				capturedState = state;
+			},
+		}),
+	);
+
+	// Specific value comparisons
+	t.deepEqual(capturedState!.focusedCell, testCell);
 });


### PR DESCRIPTION
## Summary
- Replace type-only tests (`typeof` checks) with behavioral tests that verify actual hook functionality
- Follow mandatory Test Data Pattern with explicit test data, operations, and specific value comparisons  
- Add comprehensive test coverage for all hook methods and edge cases
- Use proper React testing patterns with `onStateChange` callback and `act()`

## Changes Made
- **Removed**: Type-only tests that only verified function existence
- **Added**: 7 behavioral tests covering:
  - Initial state verification
  - Focus changes for regular and attendance issues
  - Blur event handling (should be ignored)
  - Focus clearing functionality
  - Cell focus checking logic  
  - Direct state updates via `setFocusedCell`

## Test Pattern Compliance
All tests now follow the mandatory 3-part structure:
1. **Explicit test data** - Define expected inputs and outputs at the top
2. **Operations** - Execute hook functionality in the middle
3. **Specific value comparisons** - Verify exact expected results at the bottom

## Resolves
Fixes #247

🤖 Generated with [Claude Code](https://claude.ai/code)