### PR TITLE
Update CI to use Node.js 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [24.x]
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- Updates CI matrix from Node.js 18.x, 20.x to only 24.x
- Simplifies CI to use only the latest LTS version
- Maintains matrix structure for easy addition of Node.js 26 when available

## Test plan
- [x] Local tests pass with current Node.js version
- [x] Local linting passes
- [ ] CI tests pass with Node.js 24

🤖 Generated with [Claude Code](https://claude.ai/code)