### PR TITLE
Migrate useNavigationState hook to use WeekRange instead of Date

### DIFF
--- a/source/components/WeeklyTimetableView.tsx
+++ b/source/components/WeeklyTimetableView.tsx
@@ -9,12 +9,10 @@ import {useDeleteOperations} from '../hooks/useDeleteOperations.js';
 import {useAttendanceManagement} from '../hooks/useAttendanceManagement.js';
 import {useNavigationState} from '../hooks/useNavigationState.js';
 import type {LocalDate} from '../domain/LocalDate.js';
-import {LocalDate as LocalDateClass} from '../domain/LocalDate.js';
 import {useTitleResolver} from '../hooks/useTitleResolver.js';
 import {useActiveAreaResolver} from '../hooks/useActiveAreaResolver.js';
 import {useNotification} from '../hooks/useNotification.js';
 import {JiraClient, type JiraConfig} from '../jira-client.js';
-import {WeekRange} from '../domain/WeekRange.js';
 import type {IssueKey} from '../domain/IssueKey.js';
 import {
 	isBrowserOpenSupported,
@@ -88,7 +86,7 @@ export function WeeklyTimetableView({
 		return `${dayName}, ${dateObject.getDate()}. ${monthName}`;
 	};
 
-	const weekRange = WeekRange.fromDate(LocalDateClass.fromDate(currentWeek));
+	const weekRange = currentWeek;
 
 	// Memoize favoriteIssues to prevent unnecessary re-renders
 	const favoriteIssues = useMemo(
@@ -168,7 +166,7 @@ export function WeeklyTimetableView({
 
 	// Title resolution
 	const {title: resolvedTitle, titleColor} = useTitleResolver({
-		currentWeek: LocalDateClass.fromDate(currentWeek),
+		currentWeek,
 		worklogForm,
 		deleteCandidate,
 		deleteAttendanceCandidate,

--- a/source/hooks/useNavigationState.ts
+++ b/source/hooks/useNavigationState.ts
@@ -1,4 +1,5 @@
 import {useState} from 'react';
+import {WeekRange} from '../domain/WeekRange.js';
 
 export type ActiveArea =
 	| 'timetable'
@@ -11,13 +12,13 @@ export type ActiveArea =
 	| 'align-time-confirmation';
 
 export type UseNavigationStateOptions = {
-	initialWeek?: Date;
+	initialWeek?: WeekRange;
 	initialActiveArea?: ActiveArea;
 };
 
 export type UseNavigationStateReturn = {
 	// State
-	currentWeek: Date;
+	currentWeek: WeekRange;
 	activeArea: ActiveArea;
 
 	// Week navigation
@@ -37,29 +38,26 @@ export type UseNavigationStateReturn = {
 export function useNavigationState(
 	options: UseNavigationStateOptions = {},
 ): UseNavigationStateReturn {
-	const {initialWeek = new Date(), initialActiveArea = 'timetable'} = options;
+	const {initialWeek = WeekRange.current(), initialActiveArea = 'timetable'} =
+		options;
 
 	const [currentWeek, setCurrentWeek] = useState(initialWeek);
 	const [activeArea, setActiveArea] = useState<ActiveArea>(initialActiveArea);
 
 	const navigateToPreviousWeek = () => {
-		const newWeek = new Date(currentWeek);
-		newWeek.setDate(currentWeek.getDate() - 7);
-		setCurrentWeek(newWeek);
+		setCurrentWeek(currentWeek.previous());
 		// Return focus to table after navigation
 		setActiveArea('timetable');
 	};
 
 	const navigateToNextWeek = () => {
-		const newWeek = new Date(currentWeek);
-		newWeek.setDate(currentWeek.getDate() + 7);
-		setCurrentWeek(newWeek);
+		setCurrentWeek(currentWeek.next());
 		// Return focus to table after navigation
 		setActiveArea('timetable');
 	};
 
 	const navigateToCurrentWeek = () => {
-		setCurrentWeek(new Date());
+		setCurrentWeek(WeekRange.current());
 		// Return focus to table after navigation
 		setActiveArea('timetable');
 	};

--- a/source/hooks/useTitleResolver.test.ts
+++ b/source/hooks/useTitleResolver.test.ts
@@ -2,6 +2,7 @@ import test from 'ava';
 import {IssueKey} from '../domain/IssueKey.js';
 import {Duration} from '../domain/Duration.js';
 import {LocalDate} from '../domain/LocalDate.js';
+import {WeekRange} from '../domain/WeekRange.js';
 import {useTitleResolver} from './useTitleResolver.js';
 import type {
 	DeleteCandidate,
@@ -61,7 +62,7 @@ test('useTitleResolver returns worklog form title when form is visible', t => {
 	});
 
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm,
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -79,7 +80,7 @@ test('useTitleResolver returns delete confirmation title with red color', t => {
 	});
 
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm: createWorklogForm(),
 		deleteCandidate,
 		deleteAttendanceCandidate: undefined,
@@ -97,7 +98,7 @@ test('useTitleResolver returns delete attendance confirmation title with red col
 	});
 
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate,
@@ -115,7 +116,7 @@ test('useTitleResolver returns attendance edit title', t => {
 	});
 
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -129,7 +130,7 @@ test('useTitleResolver returns attendance edit title', t => {
 
 test('useTitleResolver returns week title as default', t => {
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'), // Monday
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')), // Monday
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -152,7 +153,7 @@ test('useTitleResolver prioritizes worklog form over other states', t => {
 	const attendanceEdit = createAttendanceEdit();
 
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm,
 		deleteCandidate,
 		deleteAttendanceCandidate: undefined,
@@ -166,7 +167,7 @@ test('useTitleResolver prioritizes worklog form over other states', t => {
 
 test('useTitleResolver handles delete confirmation without candidate', t => {
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -181,7 +182,7 @@ test('useTitleResolver handles delete confirmation without candidate', t => {
 
 test('useTitleResolver handles attendance edit without data', t => {
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-15'),
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -197,7 +198,7 @@ test('useTitleResolver handles attendance edit without data', t => {
 test('useTitleResolver formats different weekdays correctly', t => {
 	// Test Tuesday
 	const tuesdayResult = useTitleResolver({
-		currentWeek: new Date('2024-01-16'), // Tuesday
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-16')), // Tuesday
 		worklogForm: createWorklogForm({
 			isVisible: true,
 			issueKey: IssueKey.fromString('TEST-456'),
@@ -213,7 +214,7 @@ test('useTitleResolver formats different weekdays correctly', t => {
 
 	// Test Sunday (week start)
 	const sundayResult = useTitleResolver({
-		currentWeek: new Date('2024-01-14'), // Sunday
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-14')), // Sunday
 		worklogForm: createWorklogForm({
 			isVisible: true,
 			issueKey: IssueKey.fromString('TEST-789'),
@@ -231,7 +232,7 @@ test('useTitleResolver formats different weekdays correctly', t => {
 test('useTitleResolver handles different months in week title', t => {
 	// Week in January 2024 (German week: Monday to Friday)
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-01-01'), // Monday Jan 1st
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-01-01')), // Monday Jan 1st
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -246,7 +247,7 @@ test('useTitleResolver handles different months in week title', t => {
 test('useTitleResolver handles year boundary correctly', t => {
 	// Test year boundary: week spanning December 2024 to January 2025
 	const result = useTitleResolver({
-		currentWeek: new Date('2024-12-30'), // Monday
+		currentWeek: WeekRange.fromDate(LocalDate.fromString('2024-12-30')), // Monday
 		worklogForm: createWorklogForm(),
 		deleteCandidate: undefined,
 		deleteAttendanceCandidate: undefined,
@@ -262,22 +263,22 @@ test('useTitleResolver calculates German calendar weeks correctly', t => {
 	// Test various dates to ensure correct ISO 8601 week calculation
 	const testCases = [
 		{
-			date: new Date('2024-01-01'),
+			date: WeekRange.fromDate(LocalDate.fromString('2024-01-01')),
 			expectedWeek: 'KW1',
 			description: 'New Year 2024',
 		},
 		{
-			date: LocalDate.fromString('2024-01-15'),
+			date: WeekRange.fromDate(LocalDate.fromString('2024-01-15')),
 			expectedWeek: 'KW3',
 			description: 'Mid January 2024',
 		},
 		{
-			date: new Date('2024-07-15'),
+			date: WeekRange.fromDate(LocalDate.fromString('2024-07-15')),
 			expectedWeek: 'KW29',
 			description: 'Mid July 2024',
 		},
 		{
-			date: new Date('2024-12-30'),
+			date: WeekRange.fromDate(LocalDate.fromString('2024-12-30')),
 			expectedWeek: 'KW1',
 			description: 'End of 2024 (KW1 of 2025)',
 		},

--- a/source/hooks/useTitleResolver.ts
+++ b/source/hooks/useTitleResolver.ts
@@ -1,4 +1,5 @@
 import {LocalDate} from '../domain/LocalDate.js';
+import type {WeekRange} from '../domain/WeekRange.js';
 import type {
 	DeleteCandidate,
 	DeleteAttendanceCandidate,
@@ -7,7 +8,7 @@ import type {AttendanceEditState} from './useAttendanceManagement.js';
 import type {WorklogFormData} from './useWorklogForm.js';
 
 export type UseTitleResolverOptions = {
-	currentWeek: Date | LocalDate;
+	currentWeek: WeekRange;
 	worklogForm: WorklogFormData;
 	deleteCandidate: DeleteCandidate | undefined;
 	deleteAttendanceCandidate: DeleteAttendanceCandidate | undefined;
@@ -82,17 +83,8 @@ export function useTitleResolver({
 	};
 
 	// Generate week title (German week: Monday to Friday with calendar week)
-	const getWeekTitle = (week: Date | LocalDate) => {
-		// Convert LocalDate to Date if needed
-		const jsWeek =
-			week instanceof LocalDate ? new Date(week.toISOString()) : week;
-		const startOfWeek = new Date(jsWeek);
-		// German week starts on Monday: getDay() returns 0=Sunday, 1=Monday, ..., 6=Saturday
-		// To get Monday as start: if Sunday (0), go back 6 days, otherwise go back (day-1) days
-		const day = startOfWeek.getDay();
-		const daysToSubtract = day === 0 ? 6 : day - 1;
-		startOfWeek.setDate(jsWeek.getDate() - daysToSubtract);
-
+	const getWeekTitle = (weekRange: WeekRange) => {
+		const startOfWeek = weekRange.getStart().toDate();
 		// End of German work week is Friday (4 days after Monday)
 		const endOfWeek = new Date(startOfWeek);
 		endOfWeek.setDate(startOfWeek.getDate() + 4);

--- a/source/tests/hooks/useNavigationState.test.tsx
+++ b/source/tests/hooks/useNavigationState.test.tsx
@@ -8,6 +8,8 @@ import {
 	type UseNavigationStateReturn,
 } from '../../hooks/useNavigationState.js';
 import {InkTestHelpers} from '../utils/ink-test-helpers.js';
+import {WeekRange} from '../../domain/WeekRange.js';
+import {LocalDate} from '../../domain/LocalDate.js';
 
 // Test component that uses the navigation hook and reports state changes
 function TestNavigationComponent({
@@ -28,7 +30,7 @@ function TestNavigationComponent({
 
 	return (
 		<Box>
-			<Text>Week: {navigationState.currentWeek.toISOString()}</Text>
+			<Text>Week: {navigationState.currentWeek.toWeekString()}</Text>
 			<Text>ActiveArea: {navigationState.activeArea}</Text>
 		</Box>
 	);
@@ -60,7 +62,7 @@ test('useNavigationState returns initial state with defaults', (t: any) => {
 
 test('useNavigationState uses provided initial values', (t: any) => {
 	let capturedState: UseNavigationStateReturn;
-	const initialWeek = new Date('2024-01-15');
+	const initialWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-15'));
 	const initialActiveArea: ActiveArea = 'worklog-form';
 
 	render(
@@ -76,13 +78,13 @@ test('useNavigationState uses provided initial values', (t: any) => {
 	);
 
 	// Check initial state uses provided values
-	t.is(capturedState!.currentWeek.getTime(), initialWeek.getTime());
+	t.truthy(capturedState!.currentWeek.equals(initialWeek));
 	t.is(capturedState!.activeArea, initialActiveArea);
 });
 
 test('navigateToPreviousWeek moves week back by 7 days and returns to timetable', async (t: any) => {
 	let capturedState: UseNavigationStateReturn;
-	const initialWeek = new Date('2024-01-15'); // Monday
+	const initialWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-15')); // Monday
 
 	const {rerender} = render(
 		React.createElement(TestNavigationComponent, {
@@ -114,15 +116,15 @@ test('navigateToPreviousWeek moves week back by 7 days and returns to timetable'
 	);
 
 	// Check week moved back 7 days
-	const expectedDate = new Date('2024-01-08');
-	t.is(capturedState!.currentWeek.getTime(), expectedDate.getTime());
+	const expectedWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-08'));
+	t.truthy(capturedState!.currentWeek.equals(expectedWeek));
 	// Check active area returned to timetable
 	t.is(capturedState!.activeArea, 'timetable');
 });
 
 test('navigateToNextWeek moves week forward by 7 days and returns to timetable', async (t: any) => {
 	let capturedState: UseNavigationStateReturn;
-	const initialWeek = new Date('2024-01-15'); // Monday
+	const initialWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-15')); // Monday
 
 	const {rerender} = render(
 		React.createElement(TestNavigationComponent, {
@@ -154,15 +156,15 @@ test('navigateToNextWeek moves week forward by 7 days and returns to timetable',
 	);
 
 	// Check week moved forward 7 days
-	const expectedDate = new Date('2024-01-22');
-	t.is(capturedState!.currentWeek.getTime(), expectedDate.getTime());
+	const expectedWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-22'));
+	t.truthy(capturedState!.currentWeek.equals(expectedWeek));
 	// Check active area returned to timetable
 	t.is(capturedState!.activeArea, 'timetable');
 });
 
 test('navigateToCurrentWeek sets week to current date and returns to timetable', async (t: any) => {
 	let capturedState: UseNavigationStateReturn;
-	const initialWeek = new Date('2024-01-15'); // Old date
+	const initialWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-15')); // Old date
 
 	const {rerender} = render(
 		React.createElement(TestNavigationComponent, {
@@ -193,13 +195,9 @@ test('navigateToCurrentWeek sets week to current date and returns to timetable',
 		}),
 	);
 
-	// Check week is close to current date (within 1 day to account for test execution time)
-	const now = new Date();
-	const timeDiff = Math.abs(
-		capturedState!.currentWeek.getTime() - now.getTime(),
-	);
-	const daysDiff = timeDiff / (1000 * 60 * 60 * 24);
-	t.true(daysDiff < 1, 'Week should be set to current date');
+	// Check week is close to current date - should contain today's date
+	const currentWeek = WeekRange.current();
+	t.truthy(capturedState!.currentWeek.equals(currentWeek));
 
 	// Check active area returned to timetable
 	t.is(capturedState!.activeArea, 'timetable');
@@ -306,7 +304,7 @@ test('all active area values work correctly', async (t: any) => {
 
 test('week navigation preserves week calculations correctly', async (t: any) => {
 	let capturedState: UseNavigationStateReturn;
-	const startDate = new Date('2024-01-15'); // Monday
+	const startDate = WeekRange.fromDate(LocalDate.fromString('2024-01-15')); // Monday
 
 	const {rerender} = render(
 		React.createElement(TestNavigationComponent, {
@@ -360,8 +358,8 @@ test('week navigation preserves week calculations correctly', async (t: any) => 
 	);
 
 	// Should be 1 week ahead of start (15 + 7 + 7 - 7 = 22)
-	const expectedDate = new Date('2024-01-22');
-	t.is(capturedState!.currentWeek.getTime(), expectedDate.getTime());
+	const expectedWeek = WeekRange.fromDate(LocalDate.fromString('2024-01-22'));
+	t.truthy(capturedState!.currentWeek.equals(expectedWeek));
 });
 
 test('hook structure and interface validation', (t: any) => {
@@ -391,7 +389,7 @@ test('hook structure and interface validation', (t: any) => {
 	}
 
 	// Validate state types
-	t.true(capturedState!.currentWeek instanceof Date);
+	t.true(capturedState!.currentWeek instanceof WeekRange);
 	t.is(typeof capturedState!.activeArea, 'string');
 
 	// Validate function types


### PR DESCRIPTION
## Summary

- Replaces Date primitive in `useNavigationState` hook with WeekRange domain type
- Updates all consuming components and tests to work with WeekRange
- Simplifies week navigation logic using built-in WeekRange methods

## Changes Made

- **useNavigationState.ts**: Updated interface and implementation to use WeekRange
- **WeeklyTimetableView.tsx**: Simplified to use WeekRange directly
- **useTitleResolver.ts**: Updated to accept WeekRange parameter  
- **Tests**: Updated all affected tests to work with WeekRange instead of Date

## Benefits

✅ Clear week boundaries (Monday-Sunday)  
✅ Built-in week navigation methods (`previous()` / `next()`)  
✅ Consistent with other domain types  
✅ Eliminates ambiguity about "current week" date  

## Test Coverage

All tests passing including:
- Navigation state hook tests
- Title resolver tests  
- Component integration tests
- Full test suite (400+ tests)

Fixes #314

🤖 Generated with [Claude Code](https://claude.ai/code)