### PR TITLE
Migrate jira/utils.ts to use LocalDate and WeekRange instead of Date primitives

### DIFF
--- a/source/components/InlineWorklogForm.tsx
+++ b/source/components/InlineWorklogForm.tsx
@@ -76,7 +76,7 @@ export function InlineWorklogForm({
 		const result = getCommentWithPrefill(config, issueKey, recentWorklogs, {
 			isEditMode,
 			explicitDefault: defaultComment,
-			referenceDate: new Date(currentDate.toISOString()),
+			referenceDate: currentDate,
 		});
 
 		return result;
@@ -108,7 +108,7 @@ export function InlineWorklogForm({
 				{
 					isEditMode,
 					explicitDefault: defaultComment,
-					referenceDate: new Date(currentDate.toISOString()),
+					referenceDate: currentDate,
 				},
 			);
 

--- a/source/jira/utils.ts
+++ b/source/jira/utils.ts
@@ -1,5 +1,6 @@
 import process from 'node:process';
 import {Duration} from '../domain/Duration.js';
+import {LocalDate} from '../domain/LocalDate.js';
 import type {IssueKey} from '../domain/IssueKey.js';
 import {WorklogGroupService} from '../services/WorklogGroupService.js';
 import type {
@@ -146,15 +147,19 @@ export function extractIssueKeyFromInput(input: string): string | undefined {
 export function getMostRecentCommentForIssue(
 	worklogs: WorklogEntry[],
 	daysBack = 7,
-	referenceDate: Date = new Date(),
+	referenceDate: LocalDate = LocalDate.today(),
 ): string | undefined {
-	const cutoffDate = new Date(referenceDate);
-	cutoffDate.setDate(cutoffDate.getDate() - daysBack);
+	const cutoffDate = referenceDate.addDays(-daysBack);
 
 	const relevantWorklogs = worklogs
 		.filter(worklog => {
-			const worklogDate = new Date(worklog.started);
-			return worklogDate >= cutoffDate && Boolean(worklog.comment?.trim());
+			const dateString = worklog.started.split('T')[0];
+			if (!dateString) return false;
+			const worklogDate = LocalDate.fromString(dateString);
+			return (
+				worklogDate.toDate() >= cutoffDate.toDate() &&
+				Boolean(worklog.comment?.trim())
+			);
 		})
 		.sort(
 			(a, b) => new Date(b.started).getTime() - new Date(a.started).getTime(),
@@ -210,7 +215,7 @@ export function getCommentWithPrefill(
 	options: {
 		isEditMode: boolean;
 		explicitDefault?: string;
-		referenceDate: Date;
+		referenceDate: LocalDate;
 	},
 ): string {
 	// If explicit default comment is provided AND we're in edit mode, use it
@@ -220,8 +225,6 @@ export function getCommentWithPrefill(
 
 	// Try to find most recent comment for this issue using configured lookback days
 	const lookbackDays = resolveCommentPrefillDays(config, issueKey);
-	const cutoffDate = new Date(options.referenceDate);
-	cutoffDate.setDate(cutoffDate.getDate() - lookbackDays);
 
 	const recentComment = getMostRecentCommentForIssue(
 		recentWorklogs,

--- a/source/tests/jira/utils.test.ts
+++ b/source/tests/jira/utils.test.ts
@@ -194,11 +194,7 @@ test('getMostRecentCommentForIssue uses custom reference date', t => {
 
 	// Reference date: August 22nd (should look back 7 days to August 15th)
 	const referenceDate = LocalDate.fromString('2025-08-22');
-	const result = getMostRecentCommentForIssue(
-		worklogs,
-		7,
-		referenceDate.toDate(),
-	);
+	const result = getMostRecentCommentForIssue(worklogs, 7, referenceDate);
 
 	// Should find August 20th comment (within 7 days of August 22nd)
 	// Should NOT find July 23rd comment (30 days old)
@@ -219,11 +215,7 @@ test('getMostRecentCommentForIssue with reference date excludes old worklogs', t
 
 	// Reference date: August 22nd (should look back 7 days to August 15th)
 	const referenceDate = LocalDate.fromString('2025-08-22');
-	const result = getMostRecentCommentForIssue(
-		worklogs,
-		7,
-		referenceDate.toDate(),
-	);
+	const result = getMostRecentCommentForIssue(worklogs, 7, referenceDate);
 
 	// July 23rd is more than 7 days before August 22nd, should return undefined
 	t.is(result, undefined);
@@ -258,7 +250,7 @@ test('getCommentWithPrefill uses reference date for filtering', t => {
 		worklogs,
 		{
 			isEditMode: false,
-			referenceDate: referenceDate.toDate(),
+			referenceDate,
 		},
 	);
 
@@ -295,7 +287,7 @@ test('getCommentWithPrefill finds recent comment with reference date', t => {
 		worklogs,
 		{
 			isEditMode: false,
-			referenceDate: referenceDate.toDate(),
+			referenceDate,
 		},
 	);
 
@@ -338,7 +330,7 @@ test('getCommentWithPrefill respects configurable lookback days with reference d
 		worklogs,
 		{
 			isEditMode: false,
-			referenceDate: referenceDate.toDate(),
+			referenceDate,
 		},
 	);
 
@@ -374,7 +366,7 @@ test('getCommentWithPrefill uses explicit default in edit mode regardless of ref
 		{
 			isEditMode: true,
 			explicitDefault: 'Edit mode comment',
-			referenceDate: referenceDate.toDate(),
+			referenceDate,
 		},
 	);
 


### PR DESCRIPTION
## Summary

- Replace Date primitives with LocalDate domain types in `getMostRecentCommentForIssue()` and `getCommentWithPrefill()`
- Update function signatures to accept LocalDate parameters instead of Date
- Use LocalDate.addDays() for date arithmetic instead of manual date manipulation
- Parse worklog dates using LocalDate.fromString() for type safety
- Update InlineWorklogForm component to pass LocalDate directly
- Update all tests to use LocalDate instead of Date conversions

## Changes Made

### Core Functions Updated
- `getMostRecentCommentForIssue()` - Now accepts LocalDate parameter and uses domain methods
- `getCommentWithPrefill()` - Updated to use LocalDate for reference date handling

### Files Modified
- `source/jira/utils.ts` - Core utility functions migrated
- `source/components/InlineWorklogForm.tsx` - Updated function calls  
- `source/tests/jira/utils.test.ts` - All tests updated for LocalDate

## Benefits

- **Type Safety**: Functions now use domain types instead of primitives
- **Consistency**: Aligns with the domain layer architecture throughout the codebase
- **Maintainability**: Date operations handled by well-tested domain methods
- **Backward Compatibility**: All existing functionality preserved

## Test Plan

- [x] All existing tests pass with LocalDate integration
- [x] Date arithmetic works correctly with LocalDate.addDays()
- [x] Worklog date parsing handles ISO date strings properly  
- [x] Comment prefilling logic maintains same behavior
- [x] Integration tests verify end-to-end functionality
- [x] XO linting passes without issues

Resolves #317

🤖 Generated with [Claude Code](https://claude.ai/code)