### PR TITLE
Create WorklogSummary value object to replace primitive object literals (#328)

### DIFF
--- a/source/domain/WeeklyWorklogSummary.ts
+++ b/source/domain/WeeklyWorklogSummary.ts
@@ -3,6 +3,7 @@
 
 import type {IssueKey} from './IssueKey.js';
 import type {LocalDate} from './LocalDate.js';
+import type {Duration} from './Duration.js';
 
 export type WeeklyWorklogSummary = {
 	weekStart: LocalDate;
@@ -17,15 +18,65 @@ export type DailyWorklogSummary = {
 	issues: IssueWorklogEntry[];
 };
 
-export type IssueWorklogEntry = {
+type WorklogSummaryData = {
 	issueKey: IssueKey;
 	issueSummary: string;
-	hours: number;
-	// Optional worklog ID - only set when there's exactly one worklog for this issue/date
+	duration: Duration;
 	worklogId?: string;
-	// Optional comment - only set when there's exactly one worklog for this issue/date
 	comment?: string;
 };
+
+type CreateWorklogSummaryOptions = {
+	issueKey: IssueKey;
+	issueSummary: string;
+	duration: Duration;
+	worklogId?: string;
+	comment?: string;
+};
+
+export class WorklogSummary {
+	static create(options: CreateWorklogSummaryOptions): WorklogSummary {
+		return new WorklogSummary({
+			issueKey: options.issueKey,
+			issueSummary: options.issueSummary,
+			duration: options.duration,
+			worklogId: options.worklogId,
+			comment: options.comment,
+		});
+	}
+
+	constructor(private readonly data: WorklogSummaryData) {}
+
+	get issueKey(): IssueKey {
+		return this.data.issueKey;
+	}
+
+	get issueSummary(): string {
+		return this.data.issueSummary;
+	}
+
+	get duration(): Duration {
+		return this.data.duration;
+	}
+
+	get worklogId(): string | undefined {
+		return this.data.worklogId;
+	}
+
+	get comment(): string | undefined {
+		return this.data.comment;
+	}
+
+	get hours(): number {
+		return this.data.duration.toHours();
+	}
+
+	get formattedDuration(): string {
+		return this.data.duration.toString();
+	}
+}
+
+export type IssueWorklogEntry = WorklogSummary;
 
 // Additional interfaces for worklog API responses
 export type WorklogResponse = {

--- a/source/tests/components/TimetableGrid.attendance.test.ts
+++ b/source/tests/components/TimetableGrid.attendance.test.ts
@@ -4,7 +4,9 @@ import {render} from 'ink-testing-library';
 import {IssueKey} from '../../domain/IssueKey.js';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
 import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {WorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
+import {Duration} from '../../domain/Duration.js';
 import {InkTestHelpers} from '../utils/ink-test-helpers.js';
 
 // Tests for attendance integration and delta calculations
@@ -215,11 +217,11 @@ test('TimetableGrid shows delta row with positive values in red', async t => {
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8, // Logged more than attended
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -278,11 +280,11 @@ test('TimetableGrid shows delta row with zero values in green', async t => {
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8.5, // Logged exactly same as attended
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8.5,
-					},
+						duration: Duration.fromHours(8.5),
+					}),
 				],
 			},
 		],
@@ -342,11 +344,11 @@ test('TimetableGrid shows delta row with negative values in red', async t => {
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8, // Logged less than attended
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -397,11 +399,11 @@ test('TimetableGrid shows dash in delta row when no attendance data', async t =>
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -468,11 +470,11 @@ test('TimetableGrid shows attendance and delta rows at bottom after daily total'
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -544,11 +546,11 @@ test('TimetableGrid does not show delta row when no attendance manager', t => {
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],

--- a/source/tests/components/TimetableGrid.favorites.test.ts
+++ b/source/tests/components/TimetableGrid.favorites.test.ts
@@ -4,8 +4,10 @@ import {render} from 'ink-testing-library';
 import figures from 'figures';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
 import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {WorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
 import {IssueKey} from '../../domain/IssueKey.js';
+import {Duration} from '../../domain/Duration.js';
 
 test('TimetableGrid shows favorite issues with asterisk marker', t => {
 	const sampleData: WeeklyWorklogSummary = {
@@ -16,16 +18,16 @@ test('TimetableGrid shows favorite issues with asterisk marker', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 6,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5417'),
 						issueSummary: 'Favorite issue',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'Regular issue',
-						hours: 3,
-					},
+						duration: Duration.fromHours(3),
+					}),
 				],
 			},
 		],
@@ -77,11 +79,11 @@ test('TimetableGrid handles favorite issues without worklogs', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 3,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'Issue with worklog',
-						hours: 3,
-					},
+						duration: Duration.fromHours(3),
+					}),
 				],
 			},
 		],
@@ -187,16 +189,16 @@ test('TimetableGrid displays aliases for favorite issues', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 6,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'Dev work issue',
-						hours: 4,
-					},
-					{
+						duration: Duration.fromHours(4),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5419'),
 						issueSummary: 'Monitoring issue',
-						hours: 2,
-					},
+						duration: Duration.fromHours(2),
+					}),
 				],
 			},
 		],
@@ -256,11 +258,11 @@ test('TimetableGrid shows original key when no alias is configured', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 4,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'Issue without alias',
-						hours: 4,
-					},
+						duration: Duration.fromHours(4),
+					}),
 				],
 			},
 		],
@@ -301,16 +303,16 @@ test('TimetableGrid handles mixed alias and non-alias favorites', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 6,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'Dev work',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5419'),
 						issueSummary: 'Regular work',
-						hours: 3,
-					},
+						duration: Duration.fromHours(3),
+					}),
 				],
 			},
 		],

--- a/source/tests/components/TimetableGrid.groups.test.ts
+++ b/source/tests/components/TimetableGrid.groups.test.ts
@@ -3,8 +3,10 @@ import React from 'react';
 import {render} from 'ink-testing-library';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
 import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {WorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
 import {IssueKey} from '../../domain/IssueKey.js';
+import {Duration} from '../../domain/Duration.js';
 
 test('TimetableGrid shows dash for empty group total', t => {
 	// Create data with the group issue but 0 hours
@@ -16,11 +18,11 @@ test('TimetableGrid shows dash for empty group total', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 0,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 0, // No hours logged
-					},
+						duration: Duration.fromHours(0), // No hours logged
+					}),
 				],
 			},
 		],
@@ -76,11 +78,11 @@ test('TimetableGrid shows group total with hours suffix when not empty', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -136,11 +138,11 @@ test('TimetableGrid shows group total with desired amount and status', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test work',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],

--- a/source/tests/components/TimetableGrid.navigation.test.ts
+++ b/source/tests/components/TimetableGrid.navigation.test.ts
@@ -2,8 +2,12 @@ import test from 'ava';
 import React from 'react';
 import {render} from 'ink-testing-library';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
-import {type WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {
+	type WeeklyWorklogSummary,
+	WorklogSummary,
+} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
+import {Duration} from '../../domain/Duration.js';
 import type {FavoriteIssue, JiraConfig} from '../../jira-client.js';
 import {IssueKey} from '../../domain/IssueKey.js';
 
@@ -19,16 +23,16 @@ const mockData: WeeklyWorklogSummary = {
 			date: LocalDate.fromString('2023-01-02'),
 			totalHours: 8,
 			issues: [
-				{
+				WorklogSummary.create({
 					issueKey: IssueKey.fromString('PROJ-1'),
 					issueSummary: 'First issue',
-					hours: 4,
-				},
-				{
+					duration: Duration.fromHours(4),
+				}),
+				WorklogSummary.create({
 					issueKey: IssueKey.fromString('PROJ-2'),
 					issueSummary: 'Second issue',
-					hours: 4,
-				},
+					duration: Duration.fromHours(4),
+				}),
 			],
 		},
 	],

--- a/source/tests/components/TimetableGrid.sorting.test.ts
+++ b/source/tests/components/TimetableGrid.sorting.test.ts
@@ -2,8 +2,12 @@ import test from 'ava';
 import React from 'react';
 import {render} from 'ink-testing-library';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
-import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {
+	type WeeklyWorklogSummary,
+	WorklogSummary,
+} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
+import {Duration} from '../../domain/Duration.js';
 import {IssueKey} from '../../domain/IssueKey.js';
 
 test('TimetableGrid sorts issues by project prefix and number', t => {
@@ -15,31 +19,31 @@ test('TimetableGrid sorts issues by project prefix and number', t => {
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 12,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2457'),
 						issueSummary: 'DEF issue 2457',
-						hours: 2,
-					},
-					{
+						duration: Duration.fromHours(2),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5417'),
 						issueSummary: 'ABC issue 5417',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('DEF-2456'),
 						issueSummary: 'DEF issue 2456',
-						hours: 1,
-					},
-					{
+						duration: Duration.fromHours(1),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5420'),
 						issueSummary: 'ABC issue 5420',
-						hours: 4,
-					},
-					{
+						duration: Duration.fromHours(4),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-5419'),
 						issueSummary: 'ABC issue 5419',
-						hours: 2,
-					},
+						duration: Duration.fromHours(2),
+					}),
 				],
 			},
 		],
@@ -89,21 +93,21 @@ test('TimetableGrid sorts issues with different project prefixes correctly', t =
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 9,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ZZZ-100'),
 						issueSummary: 'Last project issue',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('AAA-200'),
 						issueSummary: 'First project issue',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('BBB-50'),
 						issueSummary: 'Second project issue',
-						hours: 3,
-					},
+						duration: Duration.fromHours(3),
+					}),
 				],
 			},
 		],
@@ -142,16 +146,16 @@ test('TimetableGrid sorts issues numerically within same project (124 before 102
 				date: LocalDate.fromString('2024-10-18'),
 				totalHours: 6,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-1029'),
 						issueSummary: 'Higher number issue',
-						hours: 3,
-					},
-					{
+						duration: Duration.fromHours(3),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('ABC-124'),
 						issueSummary: 'Lower number issue',
-						hours: 3,
-					},
+						duration: Duration.fromHours(3),
+					}),
 				],
 			},
 		],

--- a/source/tests/components/TimetableGrid.states.test.ts
+++ b/source/tests/components/TimetableGrid.states.test.ts
@@ -2,8 +2,12 @@ import test from 'ava';
 import React from 'react';
 import {render} from 'ink-testing-library';
 import {TimetableGrid} from '../../components/TimetableGrid.js';
-import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {
+	type WeeklyWorklogSummary,
+	WorklogSummary,
+} from '../../domain/WeeklyWorklogSummary.js';
 import {LocalDate} from '../../domain/LocalDate.js';
+import {Duration} from '../../domain/Duration.js';
 import {IssueKey} from '../../domain/IssueKey.js';
 
 test('TimetableGrid shows loading state', t => {
@@ -55,11 +59,11 @@ test('TimetableGrid renders table header', t => {
 				date: LocalDate.fromString('2024-10-19'),
 				totalHours: 4,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue Summary',
-						hours: 4,
-					},
+						duration: Duration.fromHours(4),
+					}),
 				],
 			},
 		],
@@ -94,11 +98,11 @@ test('TimetableGrid displays dates in weekday headers', t => {
 				date: LocalDate.fromString('2024-10-14'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test Issue',
-						hours: 8,
-					},
+						duration: Duration.fromHours(8),
+					}),
 				],
 			},
 		],
@@ -132,16 +136,16 @@ test('TimetableGrid renders issue data correctly', t => {
 				date: LocalDate.fromString('2024-10-18'), // Friday
 				totalHours: 5.5,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue Summary',
-						hours: 4,
-					},
-					{
+						duration: Duration.fromHours(4),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue Summary',
-						hours: 1.5,
-					},
+						duration: Duration.fromHours(1.5),
+					}),
 				],
 			},
 		],
@@ -170,11 +174,11 @@ test('TimetableGrid formats hours correctly', t => {
 				date: LocalDate.fromString('2024-10-18'), // Friday
 				totalHours: 2.5,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue Summary',
-						hours: 2.5,
-					},
+						duration: Duration.fromHours(2.5),
+					}),
 				],
 			},
 		],
@@ -201,16 +205,16 @@ test('TimetableGrid shows daily totals', t => {
 				date: LocalDate.fromString('2024-10-18'), // Friday
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'First Issue',
-						hours: 4,
-					},
-					{
+						duration: Duration.fromHours(4),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-118'),
 						issueSummary: 'Second Issue',
-						hours: 4,
-					},
+						duration: Duration.fromHours(4),
+					}),
 				],
 			},
 		],
@@ -238,11 +242,11 @@ test('TimetableGrid shows week total', t => {
 				date: LocalDate.fromString('2024-10-19'),
 				totalHours: 7,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue',
-						hours: 7,
-					},
+						duration: Duration.fromHours(7),
+					}),
 				],
 			},
 		],
@@ -269,16 +273,16 @@ test('TimetableGrid handles multiple issues correctly', t => {
 				date: LocalDate.fromString('2024-10-19'),
 				totalHours: 8,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'First Issue',
-						hours: 4,
-					},
-					{
+						duration: Duration.fromHours(4),
+					}),
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-118'),
 						issueSummary: 'Second Issue',
-						hours: 4,
-					},
+						duration: Duration.fromHours(4),
+					}),
 				],
 			},
 		],
@@ -308,11 +312,11 @@ test('TimetableGrid shows dash for zero hours', t => {
 				date: LocalDate.fromString('2024-10-18'), // Only Friday has work
 				totalHours: 4,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-117'),
 						issueSummary: 'Test Issue',
-						hours: 4,
-					},
+						duration: Duration.fromHours(4),
+					}),
 				],
 			},
 		],

--- a/source/tests/hooks/useWorklogForm-validation.test.tsx
+++ b/source/tests/hooks/useWorklogForm-validation.test.tsx
@@ -7,6 +7,7 @@ import {
 	type UseWorklogFormOptions,
 } from '../../hooks/useWorklogForm.js';
 import type {JiraConfig} from '../../jira-client.js';
+import {WorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
 import {Duration} from '../../domain/Duration.js';
 import {LocalDate} from '../../domain/LocalDate.js';
 import {IssueKey} from '../../domain/IssueKey.js';
@@ -313,13 +314,13 @@ test('useWorklogForm distinguishes between edit and new worklog modes', async t 
 				date: LocalDate.fromString('2024-01-15'),
 				totalHours: 3,
 				issues: [
-					{
+					WorklogSummary.create({
 						issueKey: IssueKey.fromString('TEST-123'),
 						issueSummary: 'Test issue for worklog editing',
-						hours: 3,
+						duration: Duration.fromHours(3),
 						worklogId: 'existing-worklog-123',
 						comment: 'Existing work',
-					},
+					}),
 				],
 			},
 		],

--- a/source/tests/integration/NavigationFlow.test.ts
+++ b/source/tests/integration/NavigationFlow.test.ts
@@ -1,7 +1,11 @@
 import test from 'ava';
 import {IssueKey} from '../../domain/IssueKey.js';
 import {LocalDate} from '../../domain/LocalDate.js';
-import type {WeeklyWorklogSummary} from '../../domain/WeeklyWorklogSummary.js';
+import {Duration} from '../../domain/Duration.js';
+import {
+	type WeeklyWorklogSummary,
+	WorklogSummary,
+} from '../../domain/WeeklyWorklogSummary.js';
 import type {WeeklyAttendance} from '../../attendance/types.js';
 import type {JiraConfig} from '../../jira-client.js';
 import {TestPatterns, TestData} from '../utils/test-helpers.js';
@@ -39,11 +43,11 @@ const mockWeeklyWorklogSummary: WeeklyWorklogSummary = {
 			date: LocalDate.fromDate(mockWeekDates[0]!),
 			totalHours: 4,
 			issues: [
-				{
+				WorklogSummary.create({
 					issueKey: IssueKey.fromString('PROJ-123'),
 					issueSummary: 'Test Issue',
-					hours: 4,
-				},
+					duration: Duration.fromHours(4),
+				}),
 			],
 		},
 	],
@@ -268,9 +272,9 @@ test('data integration: attendance and worklog data structures work together', a
 		t.truthy(worklogSummary.date, 'Worklog summary must have date');
 		t.truthy(worklogSummary.issues, 'Worklog summary must have issues array');
 		t.is(
-			typeof worklogSummary.issues[0]!.hours,
+			typeof worklogSummary.issues[0]!.duration.toHours(),
 			'number',
-			'Issue hours must be number',
+			'Issue duration must convert to number of hours',
 		);
 
 		// Verify IssueKey consistency

--- a/source/tests/utils/worklog-detection.test.ts
+++ b/source/tests/utils/worklog-detection.test.ts
@@ -3,7 +3,11 @@ import {
 	detectWorklogForEdit,
 	findWorklogEntryForIssue,
 } from '../../utils/worklog-detection.js';
-import type {IssueWorklogEntry} from '../../domain/WeeklyWorklogSummary.js';
+import {
+	type IssueWorklogEntry,
+	WorklogSummary,
+} from '../../domain/WeeklyWorklogSummary.js';
+import {Duration} from '../../domain/Duration.js';
 import {IssueKey} from '../../domain/IssueKey.js';
 
 test('detectWorklogForEdit - no worklog entry', t => {
@@ -17,11 +21,11 @@ test('detectWorklogForEdit - no worklog entry', t => {
 });
 
 test('detectWorklogForEdit - zero hours worklog', t => {
-	const entry: IssueWorklogEntry = {
+	const entry: IssueWorklogEntry = WorklogSummary.create({
 		issueKey: IssueKey.fromString('TEST-123'),
 		issueSummary: 'Test issue',
-		hours: 0,
-	};
+		duration: Duration.fromHours(0),
+	});
 
 	const result = detectWorklogForEdit(entry);
 
@@ -33,13 +37,13 @@ test('detectWorklogForEdit - zero hours worklog', t => {
 });
 
 test('detectWorklogForEdit - single editable worklog with ID', t => {
-	const entry: IssueWorklogEntry = {
+	const entry: IssueWorklogEntry = WorklogSummary.create({
 		issueKey: IssueKey.fromString('TEST-123'),
 		issueSummary: 'Test issue',
-		hours: 2.5,
+		duration: Duration.fromHours(2.5),
 		worklogId: 'worklog-456',
 		comment: 'Development work',
-	};
+	});
 
 	const result = detectWorklogForEdit(entry);
 
@@ -51,12 +55,12 @@ test('detectWorklogForEdit - single editable worklog with ID', t => {
 });
 
 test('detectWorklogForEdit - single editable worklog with empty comment', t => {
-	const entry: IssueWorklogEntry = {
+	const entry: IssueWorklogEntry = WorklogSummary.create({
 		issueKey: IssueKey.fromString('TEST-123'),
 		issueSummary: 'Test issue',
-		hours: 1,
+		duration: Duration.fromHours(1),
 		worklogId: 'worklog-456',
-	};
+	});
 
 	const result = detectWorklogForEdit(entry);
 
@@ -68,12 +72,12 @@ test('detectWorklogForEdit - single editable worklog with empty comment', t => {
 });
 
 test('detectWorklogForEdit - aggregated worklog (not editable)', t => {
-	const entry: IssueWorklogEntry = {
+	const entry: IssueWorklogEntry = WorklogSummary.create({
 		issueKey: IssueKey.fromString('TEST-123'),
 		issueSummary: 'Test issue',
-		hours: 4,
+		duration: Duration.fromHours(4),
 		// No worklogId means multiple worklogs aggregated
-	};
+	});
 
 	const result = detectWorklogForEdit(entry);
 
@@ -96,12 +100,12 @@ test('detectWorklogForEdit - time spent formatting', t => {
 	];
 
 	for (const {hours, expected} of testCases) {
-		const entry: IssueWorklogEntry = {
+		const entry: IssueWorklogEntry = WorklogSummary.create({
 			issueKey: IssueKey.fromString('TEST-123'),
 			issueSummary: 'Test issue',
-			hours,
+			duration: Duration.fromHours(hours),
 			worklogId: 'worklog-456',
-		};
+		});
 
 		const result = detectWorklogForEdit(entry);
 		t.is(
@@ -114,22 +118,22 @@ test('detectWorklogForEdit - time spent formatting', t => {
 
 test('findWorklogEntryForIssue - finds matching issue', t => {
 	const dailyIssues: IssueWorklogEntry[] = [
-		{
+		WorklogSummary.create({
 			issueKey: IssueKey.fromString('TEST-123'),
 			issueSummary: 'First issue',
-			hours: 2,
-		},
-		{
+			duration: Duration.fromHours(2),
+		}),
+		WorklogSummary.create({
 			issueKey: IssueKey.fromString('TEST-456'),
 			issueSummary: 'Second issue',
-			hours: 3,
+			duration: Duration.fromHours(3),
 			worklogId: 'worklog-789',
-		},
-		{
+		}),
+		WorklogSummary.create({
 			issueKey: IssueKey.fromString('TEST-789'),
 			issueSummary: 'Third issue',
-			hours: 1,
-		},
+			duration: Duration.fromHours(1),
+		}),
 	];
 
 	const testIssueKey = IssueKey.fromString('TEST-456');
@@ -138,17 +142,17 @@ test('findWorklogEntryForIssue - finds matching issue', t => {
 	t.truthy(result);
 	t.true(result!.issueKey.equals(testIssueKey));
 	t.is(result!.issueSummary, 'Second issue');
-	t.is(result!.hours, 3);
+	t.is(result!.duration.toHours(), 3);
 	t.is(result!.worklogId, 'worklog-789');
 });
 
 test('findWorklogEntryForIssue - returns undefined for non-existent issue', t => {
 	const dailyIssues: IssueWorklogEntry[] = [
-		{
+		WorklogSummary.create({
 			issueKey: IssueKey.fromString('TEST-123'),
 			issueSummary: 'First issue',
-			hours: 2,
-		},
+			duration: Duration.fromHours(2),
+		}),
 	];
 
 	const result = findWorklogEntryForIssue(
@@ -166,12 +170,12 @@ test('findWorklogEntryForIssue - empty array', t => {
 });
 
 test('detectWorklogForEdit - edge case with very small hours', t => {
-	const entry: IssueWorklogEntry = {
+	const entry: IssueWorklogEntry = WorklogSummary.create({
 		issueKey: IssueKey.fromString('TEST-123'),
 		issueSummary: 'Test issue',
-		hours: 0.01,
+		duration: Duration.fromHours(0.01),
 		worklogId: 'worklog-456',
-	};
+	});
 
 	const result = detectWorklogForEdit(entry);
 

--- a/source/use-cases/WeeklyWorklogSummaryUseCase.ts
+++ b/source/use-cases/WeeklyWorklogSummaryUseCase.ts
@@ -12,8 +12,8 @@ import {uiLogger} from '../utils/logger.js';
 import {
 	type WeeklyWorklogSummary,
 	type DailyWorklogSummary,
-	type IssueWorklogEntry,
 	type IssueWithWorklogs,
+	WorklogSummary,
 } from '../domain/WeeklyWorklogSummary.js';
 
 export type ExecuteWeeklyWorklogSummaryOptions = {
@@ -284,31 +284,26 @@ export class WeeklyWorklogSummaryUseCase {
 			const {issue} = issuesWithWorklogs.find(
 				iwl => iwl.issue.key.toString() === issueKey,
 			)!;
-			const totalHours = worklogs.reduce(
-				(sum: number, wl): number =>
-					sum + Duration.fromSeconds(wl.timeSpentSeconds).toHours(),
+			const totalSeconds = worklogs.reduce(
+				(sum: number, wl): number => sum + wl.timeSpentSeconds,
 				0,
 			);
 
 			// Create issue entry with optional worklog ID and comment if there's exactly one worklog
-			const issueEntry: IssueWorklogEntry = {
+			const issueEntry = WorklogSummary.create({
 				issueKey: issue.key,
 				issueSummary: issue.fields.summary,
-				hours: totalHours,
-				// Only include worklog ID and comment if there's exactly one worklog for this issue/date
-				...(worklogs.length === 1 &&
-					worklogs[0] && {
-						worklogId: worklogs[0].id,
-						comment: worklogs[0].comment,
-					}),
-			};
+				duration: Duration.fromSeconds(totalSeconds),
+				worklogId: worklogs.length === 1 ? worklogs[0]?.id : undefined,
+				comment: worklogs.length === 1 ? worklogs[0]?.comment : undefined,
+			});
 
 			const existingSummary = dailyWorklogMap.get(localDateKey!);
 			if (existingSummary) {
 				existingSummary.issues.push(issueEntry);
 				dailyWorklogMap.set(localDateKey!, {
 					...existingSummary,
-					totalHours: existingSummary.totalHours + totalHours,
+					totalHours: existingSummary.totalHours + issueEntry.hours,
 				});
 			} else {
 				// Get date from the first worklog or fallback to current date
@@ -317,7 +312,7 @@ export class WeeklyWorklogSummaryUseCase {
 					: new Date();
 				dailyWorklogMap.set(localDateKey!, {
 					date: LocalDate.fromDate(worklogDate),
-					totalHours,
+					totalHours: issueEntry.hours,
 					issues: [issueEntry],
 				});
 			}
@@ -385,11 +380,13 @@ export class WeeklyWorklogSummaryUseCase {
 				summary = favorite.key.toString();
 			}
 
-			firstDay.issues.push({
-				issueKey: favorite.key,
-				issueSummary: summary,
-				hours: 0,
-			});
+			firstDay.issues.push(
+				WorklogSummary.create({
+					issueKey: favorite.key,
+					issueSummary: summary,
+					duration: Duration.fromSeconds(0),
+				}),
+			);
 		}
 	}
 
@@ -448,11 +445,13 @@ export class WeeklyWorklogSummaryUseCase {
 		// Add sliding window issues with 0 hours to the first day
 		const firstDay = dailySummaries[0]!;
 		for (const issue of slidingWindowIssuesWithoutCurrentWeekWorklogs) {
-			firstDay.issues.push({
-				issueKey: issue.key,
-				issueSummary: issue.fields.summary,
-				hours: 0,
-			});
+			firstDay.issues.push(
+				WorklogSummary.create({
+					issueKey: issue.key,
+					issueSummary: issue.fields.summary,
+					duration: Duration.fromSeconds(0),
+				}),
+			);
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Create WorklogSummary value object with Duration-based API
- Replace primitive object literals with rich domain objects  
- Eliminate primitive obsession with hours as numbers
- Update 50+ test object literals to use Duration.fromHours()

## Technical Changes
- **WorklogSummary class**: Factory method accepting Duration objects
- **WeeklyWorklogSummaryUseCase**: Uses Duration.fromSeconds() for calculations
- **Test conversions**: Systematic conversion across 9 test files

## Test Plan
- [x] All existing tests pass (38 TimetableGrid tests verified)
- [x] WeeklyWorklogSummaryUseCase tests pass (21 tests)
- [x] Build and lint successfully
- [x] Duration-based API works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)