### PR TITLE
Add vacation column to monthly statistics view

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,3 +127,4 @@ Key configuration options:
 - `slidingWindowDays` - Show recent issues across weeks
 
 Priority: Issue-specific > Group-specific > Project-specific > Global defaults
+- wenn du die anwendung starten sollst, benutze bitte das tool terminalcp und dann npm run dev:local bzw. npm start, damit kannst du die ausgaben der echten anwendung sehen und diese auch bedienen.

--- a/source/components/StatisticsGrid.tsx
+++ b/source/components/StatisticsGrid.tsx
@@ -52,6 +52,7 @@ type MonthRowProps = {
 		businessDays?: number;
 		bonusDays?: number;
 		efficiency?: number;
+		vacationDays?: number;
 	};
 	showBonus: boolean | undefined;
 	bonusConfig?: BonusConfig;
@@ -92,6 +93,9 @@ function MonthRow({month, showBonus, bonusConfig}: MonthRowProps) {
 								  ).toFixed(1)}`
 								: '-'}
 						</Text>
+					</Box>
+					<Box width={10} justifyContent="flex-end">
+						<Text color="magenta">{month.vacationDays ?? '-'}</Text>
 					</Box>
 					<Box width={10} justifyContent="flex-end">
 						<Text color={getEfficiencyColor(month.efficiency)}>
@@ -159,9 +163,9 @@ export function StatisticsGrid({statistics, bonusConfig}: StatisticsGridProps) {
 	const monthData = statistics.monthlyStats;
 	const showBonus = bonusConfig?.enabled && statistics.totalHours !== undefined;
 
-	// New layout: Month + Work Days + Billable + Non-Bill + % + Target
+	// New layout: Month + Work Days + Billable + Non-Bill + Vacation + % + Target
 	const baseWidth = 2 + 12; // Margin + Month
-	const bonusWidth = showBonus ? 12 + 12 + 14 + 10 + 8 : 0; // Work Days + Billable + Non-Bill + % + Target
+	const bonusWidth = showBonus ? 12 + 12 + 14 + 10 + 10 + 8 : 0; // Work Days + Billable + Non-Bill + Vacation + % + Target
 	const tableWidth = baseWidth + bonusWidth + 8;
 
 	return (
@@ -193,6 +197,11 @@ export function StatisticsGrid({statistics, bonusConfig}: StatisticsGridProps) {
 						<Box width={14} justifyContent="flex-end">
 							<Text bold color="white">
 								Non-Bill
+							</Text>
+						</Box>
+						<Box width={10} justifyContent="flex-end">
+							<Text bold color="white">
+								Vacation
 							</Text>
 						</Box>
 						<Box width={10} justifyContent="flex-end">
@@ -266,7 +275,7 @@ export function StatisticsGrid({statistics, bonusConfig}: StatisticsGridProps) {
 									: '-'}
 							</Text>
 						</Box>
-						<Box width={12} justifyContent="flex-end">
+						<Box width={14} justifyContent="flex-end">
 							<Text bold color="red">
 								{bonusConfig?.hoursPerBonusDay
 									? (
@@ -276,6 +285,11 @@ export function StatisticsGrid({statistics, bonusConfig}: StatisticsGridProps) {
 											) / bonusConfig.hoursPerBonusDay
 									  ).toFixed(1)
 									: '-'}
+							</Text>
+						</Box>
+						<Box width={10} justifyContent="flex-end">
+							<Text bold color="magenta">
+								{statistics.totalVacationDays ?? '-'}
 							</Text>
 						</Box>
 						<Box width={10} justifyContent="flex-end">

--- a/source/tests/components/StatisticsGrid.test.ts
+++ b/source/tests/components/StatisticsGrid.test.ts
@@ -5,6 +5,10 @@ import {StatisticsGrid} from '../../components/StatisticsGrid.js';
 import {YearlyStatistics} from '../../use-cases/StatisticsUseCase.js';
 
 // TEST DATA
+const EXPECTED_VACATION_DAYS_JANUARY = 2;
+const EXPECTED_VACATION_DAYS_FEBRUARY = 1;
+const EXPECTED_TOTAL_VACATION_DAYS = 3;
+
 const EXPECTED_YEARLY_STATISTICS = YearlyStatistics.create({
 	year: 2025,
 	monthlyStats: [
@@ -18,6 +22,7 @@ const EXPECTED_YEARLY_STATISTICS = YearlyStatistics.create({
 			nonBillableHours: 0,
 			bonusDays: 23,
 			efficiency: 100,
+			vacationDays: EXPECTED_VACATION_DAYS_JANUARY,
 		},
 		{
 			month: 'February',
@@ -29,6 +34,7 @@ const EXPECTED_YEARLY_STATISTICS = YearlyStatistics.create({
 			nonBillableHours: 0,
 			bonusDays: 20,
 			efficiency: 100,
+			vacationDays: EXPECTED_VACATION_DAYS_FEBRUARY,
 		},
 		{
 			month: 'March',
@@ -40,12 +46,14 @@ const EXPECTED_YEARLY_STATISTICS = YearlyStatistics.create({
 			nonBillableHours: 0,
 			bonusDays: 0,
 			efficiency: 0,
+			vacationDays: 0,
 		},
 	],
 	totalWorklogDays: 27,
 	totalAttendanceDays: 38,
 	totalHours: 344,
 	totalBonusDays: 43,
+	totalVacationDays: EXPECTED_TOTAL_VACATION_DAYS,
 	yearToDateEfficiency: 16.48,
 });
 
@@ -90,6 +98,7 @@ test('should render statistics table with proper headers', t => {
 	t.true(output.includes('Work Days'));
 	t.true(output.includes('Billable'));
 	t.true(output.includes('Non-Bill'));
+	t.true(output.includes('Vacation'));
 	t.true(output.includes('%'));
 	t.true(output.includes('Target'));
 });
@@ -125,6 +134,7 @@ test('should render total row with correct calculations', t => {
 	t.true(output.includes('64')); // Total business days (23+20+21)
 	t.true(output.includes('43.0')); // Total billable days (344 hours / 8 hours per day)
 	t.true(output.includes('0.0')); // Total non-billable days
+	t.true(output.includes('3')); // Total vacation days
 	t.true(output.includes('16.5%')); // Year-to-date efficiency (rounded)
 });
 
@@ -201,4 +211,56 @@ test('should use proper color formatting in output', t => {
 	// Should include efficiency indicators
 	t.true(output.includes('100.0%')); // High efficiency
 	t.true(output.includes('0.0%')); // Low efficiency
+});
+
+test('should render vacation column with correct data', t => {
+	const output = renderStatisticsGrid(EXPECTED_YEARLY_STATISTICS);
+
+	// January vacation days
+	t.true(output.includes(String(EXPECTED_VACATION_DAYS_JANUARY)));
+
+	// February vacation days
+	t.true(output.includes(String(EXPECTED_VACATION_DAYS_FEBRUARY)));
+
+	// March vacation days (zero)
+	const marchVacationPattern = /March(?:[\s\S]*?0){2}\.0%/;
+	t.regex(output, marchVacationPattern);
+
+	// Total vacation days in YTD Total row
+	t.true(output.includes(String(EXPECTED_TOTAL_VACATION_DAYS)));
+});
+
+test('should handle vacation data correctly when no vacation days exist', t => {
+	const noVacationStats = YearlyStatistics.create({
+		year: 2025,
+		monthlyStats: [
+			{
+				month: 'January',
+				worklogDays: 15,
+				attendanceDays: 20,
+				businessDays: 23,
+				totalHours: 184,
+				billableHours: 184,
+				nonBillableHours: 0,
+				bonusDays: 23,
+				efficiency: 100,
+				vacationDays: 0,
+			},
+		],
+		totalWorklogDays: 15,
+		totalAttendanceDays: 20,
+		totalHours: 184,
+		totalBonusDays: 23,
+		totalVacationDays: 0,
+		yearToDateEfficiency: 8.8,
+	});
+
+	const output = renderStatisticsGrid(noVacationStats);
+
+	// Should show 0 vacation days for January
+	t.true(output.includes('0')); // Vacation days column
+
+	// Should show 0 total vacation days in YTD row
+	const ytdVacationPattern = /YTD Total[\s\S]*?0[\s\S]*?8\.8%/;
+	t.regex(output, ytdVacationPattern);
 });

--- a/source/tests/integration/vacation-statistics.integration.test.ts
+++ b/source/tests/integration/vacation-statistics.integration.test.ts
@@ -1,0 +1,194 @@
+import test from 'ava';
+import type {JiraClient} from '../../jira-client.js';
+import {StatisticsUseCase} from '../../use-cases/StatisticsUseCase.js';
+import {LocalDate} from '../../domain/LocalDate.js';
+import type {AttendanceManager} from '../../attendance/AttendanceManager.js';
+
+// TEST DATA
+const EXPECTED_JANUARY_VACATION_DAYS = 2;
+const EXPECTED_FEBRUARY_VACATION_DAYS = 1;
+const EXPECTED_TOTAL_VACATION_DAYS = 3;
+
+const MOCK_VACATION_DATES = ['2025-01-20', '2025-01-21', '2025-02-14'];
+
+const BONUS_CONFIG = {
+	enabled: true,
+	hoursPerBonusDay: 8,
+	targetDays: 190,
+	targetAmount: 10_000,
+	currency: 'EUR' as const,
+	targets: {
+		minimum: {days: 150, label: 'Minimum', percentage: 79},
+		standard: {days: 190, label: 'Standard', percentage: 100},
+		stretch: {days: 210, label: 'Stretch', percentage: 128},
+		maximum: {days: 230, label: 'Maximum', percentage: 148},
+	},
+};
+
+// OPERATIONS
+function createMockAttendanceManager(): AttendanceManager {
+	const mockVacationRecords = MOCK_VACATION_DATES.map(date => ({
+		date: LocalDate.fromString(date),
+		type: 'VACATION' as const,
+		breakMinutes: 30,
+	}));
+
+	return {
+		async getAttendanceRange(startDate: LocalDate, endDate: LocalDate) {
+			return mockVacationRecords.filter(record => {
+				const recordDateString = record.date.toISOString();
+				const startString = startDate.toISOString();
+				const endString = endDate.toISOString();
+				return recordDateString >= startString && recordDateString <= endString;
+			});
+		},
+	} as unknown as AttendanceManager;
+}
+
+function createMockJiraClient(): JiraClient {
+	const mockCurrentUser = {
+		emailAddress: 'test@example.com',
+		displayName: 'Test User',
+	};
+
+	// Mock worklog data to generate totalHours
+	const mockWorklogs = [
+		{
+			id: '1',
+			author: mockCurrentUser,
+			started: '2025-01-15T09:00:00.000Z',
+			timeSpentSeconds: 28_800, // 8 hours
+			comment: 'Test work',
+		},
+		{
+			id: '2',
+			author: mockCurrentUser,
+			started: '2025-01-16T09:00:00.000Z',
+			timeSpentSeconds: 28_800, // 8 hours
+			comment: 'Test work',
+		},
+	];
+
+	return {
+		async getCurrentUser() {
+			return mockCurrentUser;
+		},
+
+		async searchIssuesWithWorklogs() {
+			return {
+				issues: [{key: 'TEST-123'}],
+			};
+		},
+
+		async getIssueWorklogs() {
+			return {worklogs: mockWorklogs};
+		},
+	} as unknown as JiraClient;
+}
+
+// SPECIFIC VALUE COMPARISONS
+test('vacation statistics integration: StatisticsUseCase calculates vacation days correctly', async t => {
+	const jiraClient = createMockJiraClient();
+	const attendanceManager = createMockAttendanceManager();
+	const statisticsUseCase = new StatisticsUseCase(
+		jiraClient,
+		attendanceManager,
+		BONUS_CONFIG,
+	);
+
+	// Execute statistics calculation
+	const statistics = await statisticsUseCase.execute(2025);
+
+	// Verify vacation data is calculated correctly - this is the main integration test
+	t.is(
+		statistics.monthlyStats[0]!.vacationDays,
+		EXPECTED_JANUARY_VACATION_DAYS,
+	);
+	t.is(
+		statistics.monthlyStats[1]!.vacationDays,
+		EXPECTED_FEBRUARY_VACATION_DAYS,
+	);
+	t.is(statistics.totalVacationDays, EXPECTED_TOTAL_VACATION_DAYS);
+
+	// Integration works: StatisticsUseCase properly integrates with AttendanceManager
+	// to fetch and calculate vacation statistics from vacation attendance records
+	t.pass();
+});
+
+test('vacation statistics integration: StatisticsUseCase handles no vacation data correctly', async t => {
+	const emptyAttendanceManager = {
+		async getAttendanceRange() {
+			return []; // No vacation records
+		},
+	} as unknown as AttendanceManager;
+
+	const jiraClient = createMockJiraClient();
+	const statisticsUseCase = new StatisticsUseCase(
+		jiraClient,
+		emptyAttendanceManager,
+		BONUS_CONFIG,
+	);
+
+	// Execute statistics calculation with no vacation data
+	const statistics = await statisticsUseCase.execute(2025);
+
+	// Verify no vacation days are calculated
+	t.is(statistics.totalVacationDays, 0);
+	for (const month of statistics.monthlyStats) {
+		t.is(month.vacationDays, 0);
+	}
+
+	// Integration works: StatisticsUseCase handles empty vacation data gracefully
+	t.pass();
+});
+
+test('vacation statistics integration: should calculate vacation days across multiple months correctly', async t => {
+	// Create vacation records spanning multiple months
+	const multiMonthVacationDates = [
+		'2025-01-15',
+		'2025-01-16',
+		'2025-01-17', // January: 3 days
+		'2025-02-10',
+		'2025-02-11', // February: 2 days
+		'2025-03-05', // March: 1 day
+	];
+
+	const multiMonthAttendanceManager = {
+		async getAttendanceRange(startDate: LocalDate, endDate: LocalDate) {
+			const mockRecords = multiMonthVacationDates.map(date => ({
+				date: LocalDate.fromString(date),
+				type: 'VACATION' as const,
+				breakMinutes: 30,
+			}));
+
+			return mockRecords.filter(record => {
+				const recordDateString = record.date.toISOString();
+				const startString = startDate.toISOString();
+				const endString = endDate.toISOString();
+				return recordDateString >= startString && recordDateString <= endString;
+			});
+		},
+	} as unknown as AttendanceManager;
+
+	const jiraClient = createMockJiraClient();
+	const statisticsUseCase = new StatisticsUseCase(
+		jiraClient,
+		multiMonthAttendanceManager,
+		BONUS_CONFIG,
+	);
+
+	// Execute statistics calculation
+	const statistics = await statisticsUseCase.execute(2025);
+
+	// Verify vacation days are calculated correctly for each month
+	t.is(statistics.monthlyStats[0]!.vacationDays, 3); // January
+	t.is(statistics.monthlyStats[1]!.vacationDays, 2); // February
+	t.is(statistics.monthlyStats[2]!.vacationDays, 1); // March
+
+	// Verify total vacation days
+	t.is(statistics.totalVacationDays, 6); // 3 + 2 + 1
+
+	// Integration works: StatisticsUseCase correctly calculates vacation days
+	// across multiple months from AttendanceManager vacation records
+	t.pass();
+});

--- a/source/tests/integration/vacation-statistics.integration.test.ts
+++ b/source/tests/integration/vacation-statistics.integration.test.ts
@@ -112,7 +112,6 @@ test('vacation statistics integration: StatisticsUseCase calculates vacation day
 
 	// Integration works: StatisticsUseCase properly integrates with AttendanceManager
 	// to fetch and calculate vacation statistics from vacation attendance records
-	t.pass();
 });
 
 test('vacation statistics integration: StatisticsUseCase handles no vacation data correctly', async t => {
@@ -139,7 +138,6 @@ test('vacation statistics integration: StatisticsUseCase handles no vacation dat
 	}
 
 	// Integration works: StatisticsUseCase handles empty vacation data gracefully
-	t.pass();
 });
 
 test('vacation statistics integration: should calculate vacation days across multiple months correctly', async t => {
@@ -190,5 +188,4 @@ test('vacation statistics integration: should calculate vacation days across mul
 
 	// Integration works: StatisticsUseCase correctly calculates vacation days
 	// across multiple months from AttendanceManager vacation records
-	t.pass();
 });

--- a/source/tests/use-cases/StatisticsUseCase.test.ts
+++ b/source/tests/use-cases/StatisticsUseCase.test.ts
@@ -14,6 +14,9 @@ const EXPECTED_FEBRUARY_WORKLOG_DAYS = 2;
 const EXPECTED_FEBRUARY_ATTENDANCE_DAYS = 4;
 const EXPECTED_TOTAL_WORKLOG_DAYS = 5;
 const EXPECTED_TOTAL_ATTENDANCE_DAYS = 9;
+const EXPECTED_JANUARY_VACATION_DAYS = 2;
+const EXPECTED_FEBRUARY_VACATION_DAYS = 1;
+const EXPECTED_TOTAL_VACATION_DAYS = 3;
 
 const MOCK_WORKLOG_DATES = [
 	'2025-01-15',
@@ -34,6 +37,8 @@ const MOCK_ATTENDANCE_DATES = [
 	'2025-02-12',
 	'2025-02-13',
 ];
+
+const MOCK_VACATION_DATES = ['2025-01-20', '2025-01-21', '2025-02-14'];
 
 // OPERATIONS
 function createMockJiraClient(): JiraClient {
@@ -77,9 +82,17 @@ function createMockAttendanceManager(): AttendanceManager {
 		checkOut: '17:00',
 	}));
 
+	const mockVacationRecords = MOCK_VACATION_DATES.map(date => ({
+		date: LocalDate.fromString(date),
+		type: 'VACATION' as const,
+		breakMinutes: 30,
+	}));
+
+	const allRecords = [...mockAttendanceRecords, ...mockVacationRecords];
+
 	return {
 		async getAttendanceRange(startDate: LocalDate, endDate: LocalDate) {
-			return mockAttendanceRecords.filter(record => {
+			return allRecords.filter(record => {
 				const recordDateString = record.date.toISOString();
 				const startString = startDate.toISOString();
 				const endString = endDate.toISOString();
@@ -119,6 +132,14 @@ test('should calculate yearly statistics with all monthly data', async t => {
 	t.is(marchStats.month, 'March');
 	t.is(marchStats.worklogDays, 0);
 	t.is(marchStats.attendanceDays, 0);
+
+	// Verify vacation data
+	t.is(januaryStats.vacationDays, EXPECTED_JANUARY_VACATION_DAYS);
+	t.is(februaryStats.vacationDays, EXPECTED_FEBRUARY_VACATION_DAYS);
+	t.is(marchStats.vacationDays, 0);
+
+	// Verify total vacation days
+	t.is(result.totalVacationDays, EXPECTED_TOTAL_VACATION_DAYS);
 });
 
 test('should use current year when no year specified', async t => {

--- a/source/use-cases/StatisticsUseCase.ts
+++ b/source/use-cases/StatisticsUseCase.ts
@@ -20,6 +20,7 @@ export type MonthlyStatistics = {
 	potentialHours?: number;
 	bonusDays?: number;
 	efficiency?: number;
+	vacationDays?: number;
 };
 
 export class YearlyStatistics {
@@ -33,6 +34,7 @@ export class YearlyStatistics {
 		totalNonBillableHours?: number;
 		totalBonusDays?: number;
 		yearToDateEfficiency?: number;
+		totalVacationDays?: number;
 	}): YearlyStatistics {
 		return new YearlyStatistics(data);
 	}
@@ -48,6 +50,7 @@ export class YearlyStatistics {
 			totalNonBillableHours?: number;
 			totalBonusDays?: number;
 			yearToDateEfficiency?: number;
+			totalVacationDays?: number;
 		},
 	) {}
 
@@ -87,6 +90,10 @@ export class YearlyStatistics {
 		return this.data.yearToDateEfficiency;
 	}
 
+	get totalVacationDays(): number | undefined {
+		return this.data.totalVacationDays;
+	}
+
 	getBillableHoursDuration(): Duration | undefined {
 		return this.data.totalBillableHours
 			? Duration.fromHours(this.data.totalBillableHours)
@@ -122,12 +129,17 @@ export class StatisticsUseCase {
 			(sum, month) => sum + month.attendanceDays,
 			0,
 		);
+		const totalVacationDays = monthlyStats.reduce(
+			(sum, month) => sum + (month.vacationDays ?? 0),
+			0,
+		);
 
 		const resultData = {
 			year: targetYear,
 			monthlyStats,
 			totalWorklogDays,
 			totalAttendanceDays,
+			totalVacationDays,
 		};
 
 		if (this.bonusConfig?.enabled) {
@@ -199,10 +211,13 @@ export class StatisticsUseCase {
 		month: number,
 		monthName: string,
 	): Promise<MonthlyStatistics> {
-		const [worklogDaysResult, attendanceDays] = await Promise.all([
-			this.calculateWorklogDaysAndHoursForMonth(year, month),
-			this.calculateAttendanceDaysForMonth(year, month),
-		]);
+		const [worklogDaysResult, attendanceDays, vacationDays] = await Promise.all(
+			[
+				this.calculateWorklogDaysAndHoursForMonth(year, month),
+				this.calculateAttendanceDaysForMonth(year, month),
+				this.calculateVacationDaysForMonth(year, month),
+			],
+		);
 
 		const result: MonthlyStatistics = {
 			month: monthName,
@@ -210,6 +225,7 @@ export class StatisticsUseCase {
 			attendanceDays,
 			billableHours: worklogDaysResult.billableHours,
 			nonBillableHours: worklogDaysResult.nonBillableHours,
+			vacationDays,
 		};
 
 		if (this.bonusConfig?.enabled) {
@@ -363,6 +379,34 @@ export class StatisticsUseCase {
 			return attendanceDates.length;
 		} catch (error: unknown) {
 			uiLogger.error('Error calculating attendance days', {
+				year,
+				month,
+				error: error instanceof Error ? error.message : String(error),
+			});
+			return 0;
+		}
+	}
+
+	private async calculateVacationDaysForMonth(
+		year: number,
+		month: number,
+	): Promise<number> {
+		const startDate = this.getMonthStart(year, month);
+		const endDate = this.getMonthEnd(year, month);
+
+		try {
+			const attendanceRecords = await this.attendanceManager.getAttendanceRange(
+				startDate,
+				endDate,
+			);
+
+			const vacationDates = attendanceRecords.filter(
+				record => record.type === 'VACATION',
+			);
+
+			return vacationDates.length;
+		} catch (error: unknown) {
+			uiLogger.error('Error calculating vacation days', {
 				year,
 				month,
 				error: error instanceof Error ? error.message : String(error),


### PR DESCRIPTION
## Summary

Implements vacation statistics column in the monthly statistics view as requested in GitHub issue #348, replacing the original separate vacation list approach.

### Key Changes
- **StatisticsUseCase**: Added `calculateVacationDaysForMonth()` method to count vacation days from attendance records with `type='VACATION'`
- **StatisticsGrid**: Added vacation column between Non-Bill and % columns, displayed in magenta color
- **YTD Total**: Includes total vacation days calculation in the summary row

### Technical Implementation
- Leverages existing attendance tracking infrastructure
- Vacation days are sourced from attendance records with `type='VACATION'`
- Maintains backward compatibility with existing statistics functionality
- Follows established patterns for bonus statistics integration

### Test Coverage
- **Unit Tests**: StatisticsUseCase vacation calculation logic
- **Component Tests**: StatisticsGrid vacation column rendering 
- **Integration Tests**: End-to-end vacation statistics functionality
- All existing tests continue to pass

## Test Plan
- [x] Verify vacation column appears in monthly statistics view
- [x] Confirm vacation days are correctly calculated from attendance data
- [x] Test vacation data displays in correct format and color
- [x] Validate YTD total includes vacation days
- [x] Ensure backward compatibility with existing statistics

🤖 Generated with [Claude Code](https://claude.ai/code)